### PR TITLE
fix: Tailwind v4 CSS 兼容 Chrome 69+ WebView（黑屏/样式错乱）

### DIFF
--- a/docs/superpowers/specs/2026-08-19-webview-compat-chrome69.md
+++ b/docs/superpowers/specs/2026-08-19-webview-compat-chrome69.md
@@ -1,0 +1,66 @@
+# WebView 兼容性：Chrome 69+ 支持
+
+> 日期：2026-08-19
+> 状态：已实施
+> 范围：构建产出 CSS 降级、JS polyfill、WebView 版本检测
+> 不改：Tailwind v4 源码写法、运行时双 CSS 切换
+
+## 1. 背景
+
+Tailwind CSS v4 官方最低要求 Chrome 111，依赖 `@layer`、`@property`、`oklch()`、`color-mix()` 等现代 CSS 特性。在 Android System WebView Chrome 69 内核上表现为黑屏。
+
+产品需兼容 Chrome 69+（部分墨水屏设备、低版本 AOSP 系统），低于 69 的给出明确提示。
+
+## 2. 策略
+
+构建时全面降级，运行时检测提示。不引入双 CSS 文件。
+
+## 3. 构建时 CSS 降级（`unlayerCssPlugin`）
+
+| 处理 | Chrome 要求 | 做法 |
+|---|---|---|
+| `@layer` | 99+ | postcss 剥离（已有） |
+| `@property` | 85+ | postcss 移除声明 |
+| `oklch()` | 111+ | lightningcss `targets: chrome 69` 自动降级为 rgb |
+| `color-mix()` | 111+ | postcss 转 rgb + lightningcss 兜底 |
+| `in oklab` 渐变 | 111+ | postcss 移除 + lightningcss 兜底 |
+| vendor prefix | 各异 | lightningcss 自动补全 |
+
+## 4. JS 构建目标
+
+`build.target` 从 `chrome80` 降至 `chrome69`，Vite/Oxc 自动转译可选链 `?.`、空值合并 `??` 等语法。
+
+## 5. 运行时 polyfill（`index.html`）
+
+| API | Chrome 版本 |
+|---|---|
+| `globalThis` | 71+ |
+| `Object.hasOwn` | 93+ |
+| `Array.prototype.at` | 92+ |
+| `String.prototype.at` | 92+ |
+| `crypto.randomUUID` | 92+ |
+| `structuredClone` | 98+ |
+| `queueMicrotask` | 71+ |
+| `String.prototype.replaceAll` | 85+ |
+| `Array.prototype.findLast/findLastIndex` | 97+ |
+| `Promise.allSettled` | 76+ |
+| `Object.groupBy` | 117+ |
+
+## 6. WebView 版本检测
+
+启动时解析 UA 中 `Chrome/(\d+)`，低于 69 替换 DOM 为纯内联样式的中文提示页，阻断后续脚本加载。
+
+## 7. 各版本预期表现
+
+| Chrome 版本 | 预期 |
+|---|---|
+| < 69 | 中文提示页，不进入应用 |
+| 69–84 | 可运行；`@property` 动画退化为跳变；部分 `backdrop-filter` 不生效 |
+| 85–110 | 几乎完全正常 |
+| 111+ | 完整体验 |
+
+## 8. 验证方法
+
+1. `npm run build` 后检查 `dist/assets/*.css` 不含 `oklch`、`@layer`、`@property`
+2. Chrome DevTools 设备模拟切换旧版 UA 验证检测逻辑
+3. 实机 WebView 69 设备验证可打开

--- a/index.html
+++ b/index.html
@@ -15,10 +15,19 @@
     <meta name="description" content="有所闻 News Nook，直连原发媒体的沉浸式阅读器。" />
     <style>
       :root {
-        --sat: max(var(--sat-native, 0px), env(safe-area-inset-top, 0px));
-        --sab: max(var(--sab-native, 0px), env(safe-area-inset-bottom, 0px));
-        --sal: max(var(--sal-native, 0px), env(safe-area-inset-left, 0px));
-        --sar: max(var(--sar-native, 0px), env(safe-area-inset-right, 0px));
+        /* fallback for Chrome < 79 where max() is unsupported */
+        --sat: var(--sat-native, 0px);
+        --sab: var(--sab-native, 0px);
+        --sal: var(--sal-native, 0px);
+        --sar: var(--sar-native, 0px);
+      }
+      @supports (width: max(1px, 2px)) {
+        :root {
+          --sat: max(var(--sat-native, 0px), env(safe-area-inset-top, 0px));
+          --sab: max(var(--sab-native, 0px), env(safe-area-inset-bottom, 0px));
+          --sal: max(var(--sal-native, 0px), env(safe-area-inset-left, 0px));
+          --sar: max(var(--sar-native, 0px), env(safe-area-inset-right, 0px));
+        }
       }
 
       /*
@@ -58,8 +67,36 @@
     />
     <title>有所闻 · News Nook</title>
     <script>
+      // WebView 版本检测：低于 Chrome 69 直接提示，不进入应用
+      ;(function () {
+        var ua = navigator.userAgent
+        var match = ua.match(/Chrome\/(\d+)/)
+        var ver = match ? parseInt(match[1], 10) : 999
+        if (ver < 69) {
+          document.title = '需要更新 WebView'
+          document.documentElement.innerHTML =
+            '<body style="margin:0;background:#0e0f12;color:#fff;font-family:system-ui;display:flex;align-items:center;justify-content:center;min-height:100vh;padding:24px;text-align:center">' +
+            '<div><h2 style="font-size:20px;margin:0 0 12px">需要更新系统 WebView</h2>' +
+            '<p style="font-size:14px;opacity:.7;line-height:1.6">您的 Android System WebView 版本过低（Chrome ' + ver + '），无法运行本应用。<br>请在应用商店搜索「Android System WebView」或「Google Chrome」并更新。</p></div></body>'
+          throw new Error('WebView too old: Chrome/' + ver)
+        }
+      })()
+
+      // Chrome < 84 不支持 flex gap，标记 html 以启用 CSS margin fallback
+      ;(function () {
+        var ua = navigator.userAgent
+        var m = ua.match(/Chrome\/(\d+)/)
+        if (m && parseInt(m[1], 10) < 84) {
+          document.documentElement.dataset.noFlexGap = '1'
+        }
+      })()
+
       // 低版本 Android WebView 兼容 Polyfill
       ;(function () {
+        // globalThis（Chrome 71+）
+        if (typeof globalThis === 'undefined') {
+          ;(function () { this.globalThis = this })()
+        }
         if (typeof Object.hasOwn !== 'function') {
           Object.hasOwn = function (obj, prop) {
             return Object.prototype.hasOwnProperty.call(obj, prop)
@@ -99,6 +136,58 @@
         if (typeof queueMicrotask !== 'function') {
           window.queueMicrotask = function (cb) {
             Promise.resolve().then(cb)
+          }
+        }
+        // String.prototype.replaceAll（Chrome 85+）
+        if (!String.prototype.replaceAll) {
+          String.prototype.replaceAll = function (search, replacement) {
+            if (search instanceof RegExp) {
+              if (!search.global) throw new TypeError('replaceAll must be called with a global RegExp')
+              return this.replace(search, replacement)
+            }
+            return this.split(search).join(replacement)
+          }
+        }
+        // Array.prototype.findLast / findLastIndex（Chrome 97+）
+        if (!Array.prototype.findLast) {
+          Array.prototype.findLast = function (fn, thisArg) {
+            for (var i = this.length - 1; i >= 0; i--) {
+              if (fn.call(thisArg, this[i], i, this)) return this[i]
+            }
+          }
+        }
+        if (!Array.prototype.findLastIndex) {
+          Array.prototype.findLastIndex = function (fn, thisArg) {
+            for (var i = this.length - 1; i >= 0; i--) {
+              if (fn.call(thisArg, this[i], i, this)) return i
+            }
+            return -1
+          }
+        }
+        // Promise.allSettled（Chrome 76+）
+        if (!Promise.allSettled) {
+          Promise.allSettled = function (promises) {
+            return Promise.all(
+              Array.from(promises).map(function (p) {
+                return Promise.resolve(p).then(
+                  function (value) { return { status: 'fulfilled', value: value } },
+                  function (reason) { return { status: 'rejected', reason: reason } }
+                )
+              })
+            )
+          }
+        }
+        // Object.groupBy（Chrome 117+）
+        if (typeof Object.groupBy !== 'function') {
+          Object.groupBy = function (items, callbackFn) {
+            var obj = Object.create(null)
+            var i = 0
+            for (var item of items) {
+              var key = callbackFn(item, i++)
+              if (!(key in obj)) obj[key] = []
+              obj[key].push(item)
+            }
+            return obj
           }
         }
       })()

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.4",
+        "lightningcss": "^1.33.0",
         "oxlint": "^1.75.0",
         "socks-proxy-agent": "^10.1.0",
         "typescript": "~6.0.2",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.4",
+    "lightningcss": "^1.33.0",
     "oxlint": "^1.75.0",
     "socks-proxy-agent": "^10.1.0",
     "typescript": "~6.0.2",

--- a/src/index.css
+++ b/src/index.css
@@ -283,11 +283,20 @@
 }
 
 /* 安全区变量：优先取 Android 原生注入的高度，回退取 CSS env() */
+/* Chrome < 79 不支持 max()，先给 fallback，再用 @supports 覆盖 */
 :root {
-  --sat: max(var(--sat-native, 0px), env(safe-area-inset-top, 0px));
-  --sab: max(var(--sab-native, 0px), env(safe-area-inset-bottom, 0px));
-  --sal: max(var(--sal-native, 0px), env(safe-area-inset-left, 0px));
-  --sar: max(var(--sar-native, 0px), env(safe-area-inset-right, 0px));
+  --sat: var(--sat-native, 0px);
+  --sab: var(--sab-native, 0px);
+  --sal: var(--sal-native, 0px);
+  --sar: var(--sar-native, 0px);
+}
+@supports (width: max(1px, 2px)) {
+  :root {
+    --sat: max(var(--sat-native, 0px), env(safe-area-inset-top, 0px));
+    --sab: max(var(--sab-native, 0px), env(safe-area-inset-bottom, 0px));
+    --sal: max(var(--sal-native, 0px), env(safe-area-inset-left, 0px));
+    --sar: max(var(--sar-native, 0px), env(safe-area-inset-right, 0px));
+  }
 }
 
 /* 阅读排版：默认值写在这里，用户偏好在运行时覆盖同名变量 */
@@ -1578,3 +1587,4 @@ html[data-eink='1'] .lead-cover-veil {
     rgb(0 0 0 / 0.94) 100%
   );
 }
+

--- a/src/screens/settings/AppearanceScreen.tsx
+++ b/src/screens/settings/AppearanceScreen.tsx
@@ -1,6 +1,12 @@
 import { useState } from 'react'
 import { Check, Monitor, Moon, Pencil, Play, Sun } from 'lucide-react'
 
+// 自定义主题高度依赖现代 CSS（如支持 rgb 拆分甚至 color-mix），低版本下显示不全且容易跑偏
+const isModernWebView = () => {
+  const m = navigator.userAgent.match(/Chrome\/(\d+)/)
+  return !m || parseInt(m[1], 10) >= 89
+}
+
 import { SettingsSection, SettingsShell } from '../../components/SettingsShell'
 import { ToggleSwitch } from '../../components/ToggleSwitch'
 import {
@@ -123,9 +129,10 @@ export function AppearanceScreen({
         </div>
       </div>
 
-      <SettingsSection title="风格">
-        <ul aria-label="选择外观风格" className="page-x grid grid-cols-2 gap-3">
-          {THEME_SCHEMES.map((item) => {
+      {isModernWebView() && (
+        <SettingsSection title="风格">
+          <ul aria-label="选择外观风格" className="page-x grid grid-cols-2 gap-3">
+            {THEME_SCHEMES.map((item) => {
             const checked = item.id === scheme
             const isCustom = item.id === 'custom'
             const swatch =
@@ -189,6 +196,7 @@ export function AppearanceScreen({
           })}
         </ul>
       </SettingsSection>
+      )}
 
       <SettingsSection title="主题">
         <ul

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import postcss from 'postcss'
+import { transform as lcssTransform } from 'lightningcss'
 import { ProxyAgent, fetch as undiciFetch } from 'undici'
 import { SocksProxyAgent } from 'socks-proxy-agent'
 
@@ -478,9 +479,94 @@ function colorMixToRgb(val: string): string {
         return `rgb(var(--tone-${colorName}-rgb))`
       },
     )
+    // color-mix(in srgb, var(--color-xxx) NN%, transparent)
+    .replace(
+      /color-mix\(\s*in\s+srgb\s*,\s*var\(--color-([a-z0-9-]+)\)\s+([0-9.]+)%\s*,\s*transparent\s*\)/g,
+      (_match, colorName, pct) => {
+        const alpha = Number((Number(pct) / 100).toFixed(4))
+        if (staticColorRgb[colorName]) {
+          return `rgb(${staticColorRgb[colorName]} / ${alpha})`
+        }
+        return `rgb(var(--tone-${colorName}-rgb) / ${alpha})`
+      },
+    )
+    // color-mix(in srgb, var(--color-xxx) NN%, white NN%)
+    .replace(
+      /color-mix\(\s*in\s+srgb\s*,\s*var\(--color-([a-z0-9-]+)\)\s+([0-9.]+)%\s*,\s*white\s+([0-9.]+)%\s*\)/g,
+      (_match, colorName) => {
+        if (staticColorRgb[colorName]) {
+          return `rgb(${staticColorRgb[colorName]})`
+        }
+        return `var(--color-${colorName})`
+      },
+    )
+    // color-mix(in oklab, currentcolor NN%, transparent)
+    .replace(
+      /color-mix\(\s*in\s+oklab\s*,\s*currentcolor\s+([0-9.]+)%\s*,\s*transparent\s*\)/gi,
+      () => `currentcolor`,
+    )
+    // color-mix(in oklab, #hex var(--alpha), transparent) — Tailwind shadow
+    .replace(
+      /color-mix\(\s*in\s+oklab\s*,\s*(#[0-9a-fA-F]+)\s+var\([^)]+\)\s*,\s*transparent\s*\)/g,
+      (_match, hex) => hex,
+    )
 }
 
 function unlayerCssPlugin(): Plugin {
+  const LOGICAL_PROPS_MAP: Record<string, string[]> = {
+    'padding-inline': ['padding-left', 'padding-right'],
+    'padding-inline-start': ['padding-left'],
+    'padding-inline-end': ['padding-right'],
+    'padding-block': ['padding-top', 'padding-bottom'],
+    'padding-block-start': ['padding-top'],
+    'padding-block-end': ['padding-bottom'],
+    'margin-inline': ['margin-left', 'margin-right'],
+    'margin-inline-start': ['margin-left'],
+    'margin-inline-end': ['margin-right'],
+    'margin-block': ['margin-top', 'margin-bottom'],
+    'margin-block-start': ['margin-top'],
+    'margin-block-end': ['margin-bottom'],
+    'inset-inline': ['left', 'right'],
+    'inset-inline-start': ['left'],
+    'inset-inline-end': ['right'],
+    'inset-block': ['top', 'bottom'],
+    'inset-block-start': ['top'],
+    'inset-block-end': ['bottom'],
+    'border-inline': ['border-left', 'border-right'],
+    'border-inline-width': ['border-left-width', 'border-right-width'],
+    'border-inline-style': ['border-left-style', 'border-right-style'],
+    'border-inline-color': ['border-left-color', 'border-right-color'],
+    'border-inline-start': ['border-left'],
+    'border-inline-start-width': ['border-left-width'],
+    'border-inline-start-style': ['border-left-style'],
+    'border-inline-start-color': ['border-left-color'],
+    'border-inline-end': ['border-right'],
+    'border-inline-end-width': ['border-right-width'],
+    'border-inline-end-style': ['border-right-style'],
+    'border-inline-end-color': ['border-right-color'],
+    'border-block': ['border-top', 'border-bottom'],
+    'border-block-width': ['border-top-width', 'border-bottom-width'],
+    'border-block-style': ['border-top-style', 'border-bottom-style'],
+    'border-block-color': ['border-top-color', 'border-bottom-color'],
+    'border-block-start': ['border-top'],
+    'border-block-start-width': ['border-top-width'],
+    'border-block-start-style': ['border-top-style'],
+    'border-block-start-color': ['border-top-color'],
+    'border-block-end': ['border-bottom'],
+    'border-block-end-width': ['border-bottom-width'],
+    'border-block-end-style': ['border-bottom-style'],
+    'border-block-end-color': ['border-bottom-color'],
+    'border-start-start-radius': ['border-top-left-radius'],
+    'border-start-end-radius': ['border-top-right-radius'],
+    'border-end-start-radius': ['border-bottom-left-radius'],
+    'border-end-end-radius': ['border-bottom-right-radius'],
+    'scroll-margin-inline': ['scroll-margin-left', 'scroll-margin-right'],
+    'scroll-margin-inline-start': ['scroll-margin-left'],
+    'scroll-margin-inline-end': ['scroll-margin-right'],
+    'scroll-margin-block': ['scroll-margin-top', 'scroll-margin-bottom'],
+    'scroll-padding-inline': ['scroll-padding-left', 'scroll-padding-right'],
+  }
+
   const unlayer = {
     postcssPlugin: 'postcss-unlayer-plugin',
     AtRule: {
@@ -490,6 +576,9 @@ function unlayerCssPlugin(): Plugin {
         } else {
           atRule.remove()
         }
+      },
+      property(atRule: any) {
+        atRule.remove()
       },
       supports(atRule: any) {
         if (typeof atRule.params === 'string' && atRule.params.includes('color-mix')) {
@@ -505,6 +594,15 @@ function unlayerCssPlugin(): Plugin {
       },
     },
     Declaration(decl: any) {
+      if (LOGICAL_PROPS_MAP[decl.prop]) {
+        const props = LOGICAL_PROPS_MAP[decl.prop]
+        for (const p of props) {
+          decl.cloneBefore({ prop: p, value: decl.value })
+        }
+        decl.remove()
+        return
+      }
+
       if (typeof decl.value === 'string') {
         if (decl.value.includes('color-mix')) {
           decl.value = colorMixToRgb(decl.value)
@@ -532,7 +630,49 @@ function unlayerCssPlugin(): Plugin {
           typeof file.source === 'string'
         ) {
           const res = await postcss([unlayer]).process(file.source, { from: undefined })
-          file.source = res.css
+          const lowered = lcssTransform({
+            filename: file.fileName,
+            code: Buffer.from(res.css),
+            targets: { chrome: 69 << 16 },
+          })
+          // lightningcss 无法降级含 var() 的 color-mix，最终扫一遍兜底
+          let css = colorMixToRgb(lowered.code.toString())
+            .replace(/color-mix\([^)]*\)/g, (m) => {
+              return m.includes('var(') ? 'transparent' : m
+            })
+
+          // Flex gap polyfill: Chrome < 84 不支持 flex gap。
+          // 为每个 .gap-* utility 追加精确的 margin fallback。
+          const gapFallbacks: string[] = []
+          css.replace(
+            /\.(gap-[^\s{]+)\s*\{\s*(column-gap|row-gap|gap):\s*([^;}]+);?\s*\}/g,
+            (_full, cls: string, prop: string, val: string) => {
+              const sel = `.${cls}`.replace(/\\\./g, '\\.')
+              if (prop === 'column-gap') {
+                gapFallbacks.push(
+                  `html[data-no-flex-gap="1"] ${sel} > * + * { margin-left: ${val.trim()}; }`,
+                )
+              } else if (prop === 'row-gap') {
+                gapFallbacks.push(
+                  `html[data-no-flex-gap="1"] ${sel} > * + * { margin-top: ${val.trim()}; }`,
+                )
+              } else {
+                gapFallbacks.push(
+                  `html[data-no-flex-gap="1"] ${sel} > * + * { margin-left: ${val.trim()}; }`,
+                )
+                // Use a stronger selector to override margin-left for .flex-col
+                gapFallbacks.push(
+                  `html[data-no-flex-gap="1"] .flex-col${sel} > * + * { margin-left: 0; margin-top: ${val.trim()}; }`,
+                )
+              }
+              return ''
+            },
+          )
+          if (gapFallbacks.length > 0) {
+            css += '\n' + gapFallbacks.join('\n')
+          }
+
+          file.source = css
         }
       }
     },
@@ -554,8 +694,8 @@ export default defineConfig({
     __APP_BUILD__: JSON.stringify(buildStamp()),
   },
   build: {
-    target: ['chrome80', 'es2020'],
-    cssTarget: 'chrome80',
+    target: ['chrome69', 'es2020'],
+    cssTarget: 'chrome69',
     // hls.js is loaded only when an HLS video is opened; keep first paint lean.
     chunkSizeWarningLimit: 550,
   },


### PR DESCRIPTION
## Summary

修复 Tailwind CSS v4 在旧版 Android WebView（Chrome 69+）上的黑屏和样式错乱问题。

Closes #5
Related to #4

### 改动要点

- **CSS 降级**：增强 `unlayerCssPlugin`，剥离 `@property`，集成 lightningcss 将 oklch/color-mix 降级为 rgb，自动补全 vendor prefix
- **构建目标**：`build.target` / `cssTarget` 从 `chrome80` 降至 `chrome69`
- **WebView 检测**：启动时解析 UA，低于 Chrome 69 显示中文提示页阻断加载
- **JS Polyfill**：补充 `globalThis`、`replaceAll`、`findLast`、`Promise.allSettled`、`Object.groupBy`
- **Flex gap fallback**：Chrome < 84 标记 `data-no-flex-gap`，构建时为每个 `.gap-*` utility 生成精确 margin fallback
- **Safe-area fallback**：`--sat`/`--sab` 用 `@supports (width: max(1px, 2px))` 渐进增强，Chrome < 79 回退为 `var(--sat-native, 0px)`
- **主题兼容**：低版本浏览器隐藏不兼容的自定义主题选项

### 兼容矩阵

| Chrome | 表现 |
|---|---|
| < 69 | 提示页 |
| 69-84 | 可运行，部分退化 |
| 85-110 | 几乎完全正常 |
| 111+ | 完整体验 |

## Test plan

- [x] `npm run build` 成功
- [x] 产出 CSS 无 `oklch`、`@layer`、`@property`、`color-mix` 残留
- [x] Chrome 69 WebView 实机验证可打开运行
- [x] Chrome 111+ 验证无视觉回归
