### PR TITLE
fix(prestore): 预存改为每源检查点 + 断点续传，修复进度回到 0/44

### DIFF
--- a/scripts/prestore.test.ts
+++ b/scripts/prestore.test.ts
@@ -1,9 +1,14 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 
 import {
   buildPrestorePlan,
   mergeRollingWindow,
   prestoreCandidateLimit,
+  resumableVisitedSources,
+  seedPrestoreWindows,
+  type PrestoreSyncCursor,
 } from '../src/features/prestore/model'
 import { CATEGORIES } from '../src/sources/categories'
 import {
@@ -83,5 +88,70 @@ assert.deepEqual(
   mixPlan.sources.map((target) => `${target.categoryId}:${target.source.id}`),
   ['tech:sspai', 'ai:openai-news', 'mix:ithome'],
 )
+
+// 断点续传：只有计划、预设与每源篇数都没变时才能接着上次跑。
+const cursor: PrestoreSyncCursor = {
+  planKey: plan.key,
+  presetId: plan.presetId,
+  perSourceLimit: 100,
+  visitedSourceIds: ['sspai', 'ithome', 'removed-source'],
+  updatedAt: Date.now(),
+}
+assert.deepEqual(
+  [...resumableVisitedSources(cursor, plan, 100)],
+  ['sspai', 'ithome'],
+)
+assert.equal(resumableVisitedSources(cursor, plan, 20).size, 0)
+assert.equal(resumableVisitedSources({ ...cursor, planKey: 'other' }, plan, 100).size, 0)
+assert.equal(resumableVisitedSources({ ...cursor, presetId: 'other' }, plan, 100).size, 0)
+assert.equal(resumableVisitedSources(null, plan, 100).size, 0)
+assert.equal(resumableVisitedSources(undefined, plan, 100).size, 0)
+
+// 检查点铺底：上一轮内容先按当前计划搬进草稿，中途提交才不会抹掉已有正文。
+const previousManifest = {
+  sources: {
+    sspai: { categoryId: 'tech' as const, articleIds: ['s1', 's2', 's3', 'missing'] },
+    ithome: { categoryId: 'tech' as const, articleIds: ['i1'] },
+    dropped: { categoryId: 'tech' as const, articleIds: ['d1'] },
+  },
+  articles: { s1: 1, s2: 2, s3: 3, i1: 4, d1: 5 },
+}
+const seeded = seedPrestoreWindows(plan, previousManifest, 2)
+assert.deepEqual(seeded.sources, {
+  sspai: { categoryId: 'tech', articleIds: ['s1', 's2'] },
+  ithome: { categoryId: 'tech', articleIds: ['i1'] },
+})
+// 计划外的信源不铺底；缺正文条目的 id 直接跳过。
+assert.deepEqual(seeded.articles, { s1: 1, s2: 2, i1: 4 })
+assert.deepEqual(seedPrestoreWindows(plan, null, 10), { sources: {}, articles: {} })
+
+// 中断恢复的三处约定：service 每源落检查点、跑完清空游标；hook 见到游标就续传；
+// store 能把游标读回来。逻辑本身依赖 Filesystem，这里守住调用契约不被改回原样。
+{
+  const service = readFileSync(join(process.cwd(), 'src/features/prestore/service.ts'), 'utf8')
+  const loopStart = service.indexOf('for (let sourceIndex = 0')
+  const checkpointCall = service.indexOf('await checkpoint()')
+  const finalCommit = service.indexOf('await commitPrestoreManifest(manifest)')
+  assert.ok(loopStart > 0 && checkpointCall > loopStart, '检查点必须在信源循环内提交')
+  assert.ok(finalCommit > checkpointCall, '最终提交在循环之后')
+  assert.match(service, /commitPrestoreManifest\(manifest, \{ cleanupOrphans: false \}\)/)
+  assert.match(service, /buildManifest\(null\)/)
+  assert.match(service, /resumableVisitedSources\(previous\?\.sync, plan, perSourceLimit\)/)
+  assert.match(service, /claimPrestoredBody\(article\)/)
+}
+
+{
+  const hook = readFileSync(join(process.cwd(), 'src/features/prestore/usePrestore.ts'), 'utf8')
+  assert.match(hook, /const resumable = !planChanged && Boolean\(manifest\?\.sync\)/)
+  assert.match(hook, /if \(!manualPending && !planChanged && !stale && !resumable\) return/)
+  assert.match(hook, /if \(activeControllerRef\.current\) return\s*\n\s*requestAutoSync\(\)/)
+}
+
+{
+  const store = readFileSync(join(process.cwd(), 'src/features/prestore/store.ts'), 'utf8')
+  assert.match(store, /sync: normalizeSyncCursor\(raw\.sync\)/)
+  assert.match(store, /options\.cleanupOrphans !== false/)
+  assert.match(store, /export async function claimPrestoredBody/)
+}
 
 console.log('prestore: ok')

--- a/src/features/prestore/model.ts
+++ b/src/features/prestore/model.ts
@@ -21,6 +21,19 @@ export interface PrestorePlan {
 }
 
 /**
+ * 未跑完一轮时写进清单的断点游标：记录本轮已处理过的信源，
+ * 供下次（前台恢复、网络恢复、手动更新）从中断处继续，而不是从 0 重来。
+ */
+export interface PrestoreSyncCursor {
+  planKey: string
+  presetId: string
+  perSourceLimit: number
+  /** 本轮已处理过的信源 id，顺序即计划顺序 */
+  visitedSourceIds: string[]
+  updatedAt: number
+}
+
+/**
  * Resolve the exact source traversal order for the active preset/runtime layout.
  * A source is visited once at its first concrete visible category; mix-only sources are appended last.
  */
@@ -65,6 +78,64 @@ export function buildPrestorePlan(
       .join('|')}`,
     sources,
   }
+}
+
+/** 清单里每个信源保留的滚动窗口；与 store 的 PrestoreSourceEntry 同形。 */
+export interface PrestoreWindow {
+  categoryId: CategoryId
+  articleIds: string[]
+}
+
+/** 铺底只需要读清单的窗口与条目两张表，正文条目形状由 store 决定。 */
+export interface PrestoreWindowSnapshot<Entry> {
+  sources: Record<string, PrestoreWindow>
+  articles: Record<string, Entry>
+}
+
+/**
+ * 只有计划、预设与每源篇数完全一致时，上一轮中断的游标才能续传；
+ * 任何一项变化都意味着窗口目标变了，必须整轮重来。
+ */
+export function resumableVisitedSources(
+  cursor: PrestoreSyncCursor | null | undefined,
+  plan: PrestorePlan,
+  perSourceLimit: number,
+): Set<string> {
+  if (!cursor) return new Set()
+  if (cursor.planKey !== plan.key || cursor.presetId !== plan.presetId) return new Set()
+  if (cursor.perSourceLimit !== Math.max(1, Math.floor(perSourceLimit))) return new Set()
+  const planned = new Set(plan.sources.map((target) => target.source.id))
+  return new Set(cursor.visitedSourceIds.filter((sourceId) => planned.has(sourceId)))
+}
+
+/**
+ * 用上一轮内容按当前计划铺底，作为本轮草稿的初始状态。
+ * 有了它，任何一次中途提交都是上一轮的超集：既不会让已有通勤内容消失，
+ * 也不会把仍被引用的正文误判成孤儿。计划里已删除的信源不会被带入。
+ */
+export function seedPrestoreWindows<Entry>(
+  plan: PrestorePlan,
+  previous: PrestoreWindowSnapshot<Entry> | null | undefined,
+  limit: number,
+): { sources: Record<string, PrestoreWindow>; articles: Record<string, Entry> } {
+  const target = Math.max(1, Math.floor(limit))
+  const sources: Record<string, PrestoreWindow> = {}
+  const articles: Record<string, Entry> = {}
+  if (!previous) return { sources, articles }
+
+  for (const item of plan.sources) {
+    const ids = previous.sources[item.source.id]?.articleIds ?? []
+    const kept: string[] = []
+    for (const id of ids) {
+      const entry = previous.articles[id]
+      if (!entry) continue
+      articles[id] = entry
+      kept.push(id)
+      if (kept.length >= target) break
+    }
+    if (kept.length) sources[item.source.id] = { categoryId: item.categoryId, articleIds: kept }
+  }
+  return { sources, articles }
 }
 
 /**

--- a/src/features/prestore/service.ts
+++ b/src/features/prestore/service.ts
@@ -7,11 +7,15 @@ import { revokeBlobUrl } from '../proxy/hydrateImages'
 import {
   mergeRollingWindow,
   prestoreCandidateLimit,
+  resumableVisitedSources,
+  seedPrestoreWindows,
   type PrestorePlan,
   type PrestoreSourceTarget,
+  type PrestoreSyncCursor,
 } from './model'
 import { fetchSourcePrestoreCandidates } from './sourceWindow'
 import {
+  claimPrestoredBody,
   commitPrestoreManifest,
   loadPrestoreManifest,
   writePrestoredBody,
@@ -55,24 +59,6 @@ function abortError(signal: AbortSignal): unknown {
   return signal.reason ?? new DOMException('操作已取消', 'AbortError')
 }
 
-function carryPreviousSource(
-  target: PrestoreSourceTarget,
-  previous: PrestoreManifest | null,
-  limit: number,
-  nextArticles: Record<string, PrestoreArticleEntry>,
-): string[] {
-  const ids = previous?.sources[target.source.id]?.articleIds ?? []
-  const kept: string[] = []
-  for (const id of ids) {
-    const entry = previous?.articles[id]
-    if (!entry) continue
-    nextArticles[id] = entry
-    kept.push(id)
-    if (kept.length >= limit) break
-  }
-  return kept
-}
-
 function emitProgress(
   options: SyncOptions,
   target: PrestoreSourceTarget,
@@ -109,6 +95,7 @@ async function prepareBody(
   previous: PrestoreManifest | null,
   nextArticles: Record<string, PrestoreArticleEntry>,
   signal: AbortSignal,
+  claimOrphans: boolean,
   extraSources?: NewsSource[],
 ): Promise<{ id: string; entry: PrestoreArticleEntry } | null> {
   if (article.contentType === 'video') return null
@@ -118,6 +105,11 @@ async function prepareBody(
 
   const previousEntry = previous?.articles[article.id]
   if (previousEntry) return { id: article.id, entry: previousEntry }
+
+  if (claimOrphans) {
+    const claimed = await claimPrestoredBody(article)
+    if (claimed) return { id: article.id, entry: claimed }
+  }
 
   const resolved = await resolveArticleBody(article, signal, extraSources)
   if (resolved.bodySource === 'video' || resolved.bodySource === 'blocked') return null
@@ -132,30 +124,75 @@ async function prepareBody(
 
 /**
  * 严格按当前预设的分类/信源顺序同步。信源之间串行；只有当前信源的正文并发 2。
- * 新正文全部先落盘，最后再提交新清单，因此失败/中断不会提前淘汰上一轮可读内容。
+ * 每完成一个信源就提交一次检查点（含断点游标），因此前台抢占、切后台或网络抖动
+ * 造成的中断只会丢掉当前信源的未完成部分，下次从游标继续而不是从 0 重来。
  */
 export async function syncPrestore(options: SyncOptions): Promise<PrestoreSyncResult> {
   const { plan, signal, extraSources } = options
   const perSourceLimit = Math.max(1, Math.floor(options.perSourceLimit))
   const previous = await loadPrestoreManifest()
-  const nextArticles: Record<string, PrestoreArticleEntry> = {}
-  const nextSources: PrestoreManifest['sources'] = {}
+  const seed = seedPrestoreWindows<PrestoreArticleEntry>(plan, previous, perSourceLimit)
+  const nextArticles = seed.articles
+  const nextSources: PrestoreManifest['sources'] = seed.sources
 
+  const resumed = resumableVisitedSources(previous?.sync, plan, perSourceLimit)
+  const visited: string[] = []
+  let committed = previous
   let syncedSources = 0
   let failedSources = 0
   let failedBodies = 0
+  let completedSources = 0
+  // 上一轮中断处的信源可能已有正文落盘但没进清单；只在本轮首个真正处理的信源上
+  // 尝试认领，避免其余信源为必然落空的查找付出读盘开销。
+  let claimOrphans = true
   const candidateLimit = prestoreCandidateLimit(perSourceLimit)
+
+  const buildManifest = (cursor: PrestoreSyncCursor | null): PrestoreManifest => ({
+    version: 1,
+    revision: (committed?.revision ?? 0) + 1,
+    presetId: plan.presetId,
+    planKey: plan.key,
+    perSourceLimit,
+    // updatedAt 表示“上一次完整跑完”，检查点不能把未完成的一轮伪装成已完成。
+    updatedAt: cursor ? committed?.updatedAt ?? 0 : Date.now(),
+    sync: cursor,
+    sources: { ...nextSources },
+    articles: { ...nextArticles },
+  })
+
+  const checkpoint = async () => {
+    const manifest = buildManifest({
+      planKey: plan.key,
+      presetId: plan.presetId,
+      perSourceLimit,
+      visitedSourceIds: [...visited],
+      updatedAt: Date.now(),
+    })
+    try {
+      await commitPrestoreManifest(manifest, { cleanupOrphans: false })
+      committed = manifest
+    } catch (error) {
+      log.storage.warn('Prestore checkpoint failed', manifest.revision, error)
+    }
+  }
 
   for (let sourceIndex = 0; sourceIndex < plan.sources.length; sourceIndex += 1) {
     if (signal.aborted) throw abortError(signal)
     const target = plan.sources[sourceIndex]
+
+    if (resumed.has(target.source.id)) {
+      visited.push(target.source.id)
+      completedSources += 1
+      continue
+    }
+
     emitProgress(
       options,
       target,
       sourceIndex,
       'listing',
       0,
-      syncedSources + failedSources,
+      completedSources,
       failedBodies,
       failedSources,
     )
@@ -168,21 +205,18 @@ export async function syncPrestore(options: SyncOptions): Promise<PrestoreSyncRe
     } catch (error) {
       if (signal.aborted) throw abortError(signal)
       failedSources += 1
+      completedSources += 1
+      visited.push(target.source.id)
       log.storage.warn('Prestore source list failed', target.source.id, error)
-      const carried = carryPreviousSource(target, previous, perSourceLimit, nextArticles)
-      if (carried.length) {
-        nextSources[target.source.id] = {
-          categoryId: target.categoryId,
-          articleIds: carried,
-        }
-      }
+      // 沿用铺底的上一轮窗口即可，没有新进展需要落盘。
+      // 失败也记进游标：续传要继续往前走，死源留给下一轮整体重试。
       emitProgress(
         options,
         target,
         sourceIndex,
         'source-complete',
-        carried.length,
-        syncedSources + failedSources,
+        nextSources[target.source.id]?.articleIds.length ?? 0,
+        completedSources,
         failedBodies,
         failedSources,
       )
@@ -190,6 +224,7 @@ export async function syncPrestore(options: SyncOptions): Promise<PrestoreSyncRe
     }
 
     const freshIds: string[] = []
+    let storedNew = 0
     for (
       let offset = 0;
       offset < candidates.length && freshIds.length < perSourceLimit;
@@ -202,7 +237,14 @@ export async function syncPrestore(options: SyncOptions): Promise<PrestoreSyncRe
         BODY_CONCURRENCY,
         async (article) => {
           try {
-            return await prepareBody(article, previous, nextArticles, signal, extraSources)
+            return await prepareBody(
+              article,
+              previous,
+              nextArticles,
+              signal,
+              claimOrphans,
+              extraSources,
+            )
           } catch (error) {
             if (signal.aborted) throw abortError(signal)
             failedBodies += 1
@@ -215,6 +257,7 @@ export async function syncPrestore(options: SyncOptions): Promise<PrestoreSyncRe
 
       for (const result of results) {
         if (!result || freshIds.length >= perSourceLimit) continue
+        if (!nextArticles[result.id]) storedNew += 1
         nextArticles[result.id] = result.entry
         freshIds.push(result.id)
       }
@@ -225,11 +268,12 @@ export async function syncPrestore(options: SyncOptions): Promise<PrestoreSyncRe
         sourceIndex,
         'bodies',
         freshIds.length,
-        syncedSources + failedSources - 1,
+        completedSources,
         failedBodies,
         failedSources,
       )
     }
+    claimOrphans = false
 
     const previousIds = (previous?.sources[target.source.id]?.articleIds ?? []).filter(
       (id) => Boolean(previous?.articles[id]),
@@ -245,37 +289,35 @@ export async function syncPrestore(options: SyncOptions): Promise<PrestoreSyncRe
         categoryId: target.categoryId,
         articleIds: retainedIds,
       }
+    } else {
+      delete nextSources[target.source.id]
     }
 
+    completedSources += 1
+    visited.push(target.source.id)
     emitProgress(
       options,
       target,
       sourceIndex,
       'source-complete',
       retainedIds.length,
-      syncedSources + failedSources,
+      completedSources,
       failedBodies,
       failedSources,
     )
+
+    // 只有真正写入了新正文才值得落一次检查点，避免全靠沿用时反复重写大清单。
+    if (storedNew > 0 && sourceIndex < plan.sources.length - 1) await checkpoint()
   }
 
   if (signal.aborted) throw abortError(signal)
 
   // 完全失败或一篇可用正文都没有时，绝不能用空清单覆盖上一轮通勤内容。
-  if (syncedSources === 0 || Object.keys(nextArticles).length === 0) {
-    return { manifest: previous, syncedSources, failedSources, failedBodies }
+  if ((syncedSources === 0 && resumed.size === 0) || Object.keys(nextArticles).length === 0) {
+    return { manifest: committed, syncedSources, failedSources, failedBodies }
   }
 
-  const manifest: PrestoreManifest = {
-    version: 1,
-    revision: (previous?.revision ?? 0) + 1,
-    presetId: plan.presetId,
-    planKey: plan.key,
-    perSourceLimit,
-    updatedAt: Date.now(),
-    sources: nextSources,
-    articles: nextArticles,
-  }
+  const manifest = buildManifest(null)
   await commitPrestoreManifest(manifest)
   return { manifest, syncedSources, failedSources, failedBodies }
 }

--- a/src/features/prestore/store.ts
+++ b/src/features/prestore/store.ts
@@ -5,7 +5,7 @@ import { log } from '../../lib/logger'
 import type { BodySource } from '../../lib/resolveBody'
 import type { Article } from '../../lib/types'
 import type { CategoryId } from '../../sources/categories'
-import { compactPrestoreArticle } from './model'
+import { compactPrestoreArticle, type PrestoreSyncCursor } from './model'
 
 const ROOT_DIRECTORY = 'prestore/v1'
 const BODY_DIRECTORY = `${ROOT_DIRECTORY}/articles`
@@ -37,7 +37,10 @@ export interface PrestoreManifest {
   presetId: string
   planKey: string
   perSourceLimit: number
+  /** 上一次完整跑完一轮的时间；仅有断点检查点时保持上一轮的值（从未完成为 0）。 */
   updatedAt: number
+  /** 存在即表示上一轮被中断，可从游标续传；跑完一轮后清空。 */
+  sync?: PrestoreSyncCursor | null
   sources: Record<string, PrestoreSourceEntry>
   articles: Record<string, PrestoreArticleEntry>
 }
@@ -103,6 +106,23 @@ function normalizeArticle(articleId: string, raw: unknown): Article | null {
   return raw as unknown as Article
 }
 
+function normalizeSyncCursor(raw: unknown): PrestoreSyncCursor | null {
+  if (!isRecord(raw)) return null
+  if (typeof raw.planKey !== 'string' || typeof raw.presetId !== 'string') return null
+  if (typeof raw.perSourceLimit !== 'number' || !Number.isFinite(raw.perSourceLimit)) return null
+  if (typeof raw.updatedAt !== 'number' || !Number.isFinite(raw.updatedAt)) return null
+  if (!Array.isArray(raw.visitedSourceIds)) return null
+  return {
+    planKey: raw.planKey,
+    presetId: raw.presetId,
+    perSourceLimit: Math.max(1, Math.floor(raw.perSourceLimit)),
+    visitedSourceIds: [
+      ...new Set(raw.visitedSourceIds.filter((id): id is string => typeof id === 'string' && Boolean(id))),
+    ],
+    updatedAt: raw.updatedAt,
+  }
+}
+
 function normalizeManifest(raw: unknown): PrestoreManifest | null {
   if (!isRecord(raw) || raw.version !== MANIFEST_VERSION) return null
   if (typeof raw.revision !== 'number' || !Number.isFinite(raw.revision) || raw.revision < 1) return null
@@ -148,6 +168,7 @@ function normalizeManifest(raw: unknown): PrestoreManifest | null {
     planKey: raw.planKey,
     perSourceLimit: Math.max(1, Math.floor(raw.perSourceLimit)),
     updatedAt: raw.updatedAt,
+    sync: normalizeSyncCursor(raw.sync),
     sources,
     articles,
   }
@@ -282,10 +303,9 @@ export async function writePrestoredBody(
   }
 }
 
-export async function loadPrestoredBody(articleId: string): Promise<PrestoredBody | null> {
-  const manifest = await loadPrestoreManifest()
-  if (!manifest?.articles[articleId]) return null
-
+async function readBodyFile(
+  articleId: string,
+): Promise<{ record: PrestoreBodyFile; bytes: number } | null> {
   try {
     const result = await Filesystem.readFile({
       path: bodyPath(articleId),
@@ -304,15 +324,42 @@ export async function loadPrestoredBody(articleId: string): Promise<PrestoredBod
     ) {
       return null
     }
-    return {
-      article: parsed.article,
-      html: parsed.html,
-      bodySource: parsed.bodySource as BodySource,
-      savedAt: parsed.savedAt,
-    }
-  } catch (error) {
-    log.storage.debug('Prestore body read failed', articleId, error)
+    return { record: parsed as PrestoreBodyFile, bytes: encodedBytes(result.data) }
+  } catch {
+    // 认领遗留正文时“文件不存在”是常态，是否值得记日志交给调用方判断。
     return null
+  }
+}
+
+export async function loadPrestoredBody(articleId: string): Promise<PrestoredBody | null> {
+  const manifest = await loadPrestoreManifest()
+  if (!manifest?.articles[articleId]) return null
+
+  const file = await readBodyFile(articleId)
+  if (!file) {
+    log.storage.debug('Prestore body read failed', articleId)
+    return null
+  }
+  return {
+    article: file.record.article,
+    html: file.record.html,
+    bodySource: file.record.bodySource,
+    savedAt: file.record.savedAt,
+  }
+}
+
+/**
+ * 认领上一轮中断时已落盘、但还没写进清单的正文。
+ * 命中即可跳过一次网络抓取与正文解析，中断重来的代价被限制在本地读盘。
+ */
+export async function claimPrestoredBody(article: Article): Promise<PrestoreArticleEntry | null> {
+  const file = await readBodyFile(article.id)
+  if (!file || file.record.article.sourceId !== article.sourceId) return null
+  return {
+    sourceId: file.record.article.sourceId,
+    bytes: file.bytes,
+    savedAt: file.record.savedAt,
+    article: file.record.article,
   }
 }
 
@@ -354,7 +401,10 @@ async function cleanupUnreferencedBodies(
  * 双清单提交：永远写非活动槽，完整写入后才把它作为新活动版本。
  * 进程在 writeFile 中途退出时，上一槽仍然完整；下次启动会选择 revision 更高的有效清单。
  */
-export async function commitPrestoreManifest(manifest: PrestoreManifest): Promise<void> {
+export async function commitPrestoreManifest(
+  manifest: PrestoreManifest,
+  options: { cleanupOrphans?: boolean } = {},
+): Promise<void> {
   const previousState = await loadManifestState()
   const targetSlot: ManifestSlot = previousState.manifest
     ? previousState.activeSlot === 'a' ? 'b' : 'a'
@@ -374,7 +424,9 @@ export async function commitPrestoreManifest(manifest: PrestoreManifest): Promis
     backup: previous,
   }
   manifestStatePromise = null
-  await cleanupUnreferencedBodies(manifest, previous)
+  // 断点检查点不清理孤儿：本轮已落盘、尚未入清单的正文要留给续传认领，
+  // 统一等整轮跑完的最终提交再回收。
+  if (options.cleanupOrphans !== false) await cleanupUnreferencedBodies(manifest, previous)
 }
 
 export async function clearPrestore(): Promise<void> {

--- a/src/features/prestore/usePrestore.ts
+++ b/src/features/prestore/usePrestore.ts
@@ -102,6 +102,8 @@ export function usePrestore({
         activeControllerRef.current?.abort()
         return
       }
+      // 正在同步时不要因为一次网络切换重启整轮：当前进度还在跑，打断只会丢进度。
+      if (activeControllerRef.current) return
       requestAutoSync()
     }).then((handle) => {
       if (disposed) void handle.remove()
@@ -115,6 +117,8 @@ export function usePrestore({
           activeControllerRef.current?.abort()
           return
         }
+        // 回前台本身会通过 foreground 依赖重跑 effect；同步中就别再多推一次。
+        if (activeControllerRef.current) return
         requestAutoSync()
       }).then((handle) => {
         if (disposed) void handle.remove()
@@ -128,6 +132,7 @@ export function usePrestore({
           activeControllerRef.current?.abort()
           return
         }
+        if (activeControllerRef.current) return
         requestAutoSync()
       }
       document.addEventListener('visibilitychange', onVisibility)
@@ -168,8 +173,11 @@ export function usePrestore({
         manifest?.planKey !== plan.key ||
         manifest?.perSourceLimit !== prefs.prestore.perSourceLimit ||
         manifest?.presetId !== presetId
+      // 上一轮被中断时清单里留有断点游标，恢复前台/网络后立刻续传，
+      // 不必等下一个 4 小时窗口。计划变了则本来就要整轮重来。
+      const resumable = !planChanged && Boolean(manifest?.sync)
       const stale = !manifest || Date.now() - manifest.updatedAt >= AUTO_SYNC_INTERVAL_MS
-      if (!manualPending && !planChanged && !stale) return
+      if (!manualPending && !planChanged && !stale && !resumable) return
 
       if (manualPending) handledManualSequenceRef.current = manualTriggerSequence
       const connected = await networkAvailable()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
修复 #11。

## 问题

每源篇数选 100 时，信源进度走到 2/44、3/44 就退回 0/44 重来；选 20 篇不复现。

原因不是「信源文章数不够」，而是整轮预存只在**全部信源跑完后**才提交一次清单：

1. 首页刷新、加载更多、进入阅读器（`suspend`）、切后台、网络状态变化都会 abort 当前轮；
2. abort 后 effect 重跑，内存计数清零，只能从第 0 个信源重新开始；
3. 本轮已抓好落盘的正文没有进清单，成了孤儿，下一轮全部重抓。

每源 100 篇时单个信源要跑几分钟，被打断几乎必然，于是进度反复归零。

## 改动

- **每源检查点**：每完成一个（且写入了新正文的）信源就提交一次清单，并在清单里带 `sync` 游标记录本轮已处理的信源；整轮跑完清空游标。
- **提交前铺底**：先把上一轮内容按当前计划搬进本轮草稿，保证任何中途提交都是上一轮的超集，既不会让已有通勤内容消失，也不会把仍被引用的正文误判成孤儿。检查点提交跳过孤儿回收，留到最终提交统一处理。
- **续传而非重来**：游标只在计划、预设、每源篇数完全一致时才可复用（改篇数仍然整轮重跑）；hook 见到游标即续传，不必等下一个 4 小时窗口。
- **认领遗留正文**：本轮首个真正处理的信源（即上次中断处）允许认领已落盘、未入清单的正文，把重来的代价限制在本地读盘。
- **进度真实**：进度按已完成信源数统计，续传时从 3/44 继续显示而不是归零；`updatedAt` 保持「上次完整跑完」的语义，检查点不会把未完成的一轮标记成已完成。

## 兼容性

清单 `version` 不变，`sync` 为可选字段：旧清单读入为 `null`（走整轮重跑），旧版本读到新清单会忽略该字段，行为退化为改动前。本地存储键与目录结构不变。

## 验证

- `npm run test:prestore`（新增续传游标、铺底与检查点契约用例）
- `tsc -b`、`npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebbebabd-97b1-48ee-80c7-91e84d1f360f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebbebabd-97b1-48ee-80c7-91e84d1f360f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

