### PR TITLE
fix(share): 分享预览卡显示文章标题，不再落回站点通用文案

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,7 +242,7 @@ ReaderScreen / CommentsDrawer
 
 分享      ReaderMoreMenu / EinkReaderMenu（两个入口同一流程）
             → ShareArticleSheet（应用内预览卡片，只用主题变量着色）
-            → lib/shareLink.buildShareUrl（站内短链，v2 只带原文地址 + 信源 id，见 8.6.1）
+            → lib/shareLink.buildShareUrl（站内短链，v2 带原文地址 + 信源 id + 标题，见 8.6.1）
             → lib/shareArticle
                  Android：@capacitor/share（只传 title + url，不传 text）
                  Web：navigator.share，不支持时降级 navigator.clipboard
@@ -250,7 +250,8 @@ ReaderScreen / CommentsDrawer
           拼成一段 EXTRA_TEXT（"text url"），微信把这种消息当**纯文本**、根本不去抓
           OG——这正是「新链接也出不了卡片」最常见的根因，与预览缓存无关。
           EXTRA_TEXT 恰好是一条裸 URL 时才按链接消息处理，边缘 OG 卡片才有机会展示。
-          标题、摘要、首图都由 8.6.2 的卡片承载，不需要写进消息正文。
+          摘要与首图都由 8.6.2 的卡片承载，不需要写进消息正文；标题另外编进 token，
+          边缘抓不到原文时卡片也说得出这是哪一篇（见 8.6.1）。
 
 本地搜索  LocalSearchScreen
             → lib/localSearch.loadCachedListArticles（枚举 cache:v3:* 列表缓存）
@@ -265,7 +266,7 @@ ReaderScreen / CommentsDrawer
 
 分享出去的主链接固定指向站内：`https://news.aizeek.com/a/<token>`（常量集中在 `lib/shareLink.ts` 的 `SHARE_LINK_HOST` / `SHARE_PATH_PREFIX`）。**没有任何服务端参与**——token 自带打开阅读器所需的全部字段，接收端本地解码后照常走 `resolveBody` 抽正文。出版社地址只是 token 里的一个字段，供正文抽取与用户主动「在浏览器核对原文」使用，不作为分享主链接。
 
-token 载荷当前是 **v2**：只留「能打开这篇」的两个必需字段，中文一律不进链接。v1 的短键 JSON（带标题、摘要、信源名、时间）仍然可解码，旧链接不失效。
+token 载荷当前是 **v2**：只留「能打开这篇」的必需字段，外加一行供聊天预览卡使用的标题。v1 的短键 JSON（带标题、摘要、信源名、时间）仍然可解码，旧链接不失效。
 
 ```text
 v2 明文（换行分隔，比 JSON 再省掉键名与引号）
@@ -273,9 +274,11 @@ v2 明文（换行分隔，比 JSON 再省掉键名与引号）
   第 2 行  sourceId
   第 3 行  原文地址          https:// 前缀省略不写
   第 4 行  可选 id           以 ':' 开头表示补回 `<sourceId>:` 前缀
+                            有标题而无 id 时写一行空串占位（见「标题为什么又进链接」）
+  第 5 行  可选标题          以 '!' 开头，不超过 50 字，解码时摘出来不占位置槽
   末   行  可选 salt         以 '~' 开头，解码时整行忽略（见「换新链接」）
 
-编码  Article ─ sharePayloadFromArticle ─→ { originUrl, sourceId, id? }
+编码  Article ─ sharePayloadFromArticle ─→ { originUrl, sourceId, id?, title? }
                                             ↓ 上述明文 + UTF-8 + URL-safe base64
                     buildShareUrl ─→ https://news.aizeek.com/a/<token>
                     （开发态 resolveShareOrigin 用 window.location.origin，原生壳与生产固定 news.aizeek.com）
@@ -288,8 +291,10 @@ v2 明文（换行分隔，比 JSON 再省掉键名与引号）
       Android App 唤起（launchUrl / appUrlOpen）由 lib/appDeepLink.shareTokenFromAppUrl 还原 token 后走同一条链
 ```
 
-- **为什么砍字段**：中文在 UTF-8 + base64 下膨胀三倍，v1 把标题、摘要、信源名全编进去，典型条目要 450～550 字符，聊天工具里折行、被截断就打不开。v2 网易稿 86 字符、公众号稿 82 字符（完整 URL 112 / 108）。
-- **标题与信源名从哪来**：标题不编码，打开后先显示 `SHARE_PENDING_TITLE`（「加载中…」），`resolveBody` 抽完正文由 `ResolvedBody.title` 顶掉；抽取失败退到 `SHARE_FALLBACK_TITLE`（「分享的文章」）。信源名查 `sources/registry`，不认识就写「分享来源」。`withResolvedShareTitle` 保证落进正文缓存与稍后读的是补齐后的标题，不是占位符。
+- **为什么砍字段**：中文在 UTF-8 + base64 下膨胀三倍，v1 把标题、摘要、信源名全编进去，典型条目要 450～550 字符，聊天工具里折行、被截断就打不开。v2 只留必需字段时网易稿 86 字符、公众号稿 82 字符；带上标题后是 198 / 174（带 salt 206 / 182，完整 URL 232 / 208），仍不到 v1 的一半。摘要与信源名依旧不编码。
+- **标题为什么又进链接**：聊天预览卡的标题由边缘现拼（见 8.6.2），原本只能靠边缘现抓一次原文——被反爬拦住、或抓取端被误判成真人时，卡片就只剩「一篇文章」甚至站点通用文案，对方看不出分享的是哪一篇。分享时 App 手里本来就有真标题，编进 token 后边缘零依赖也能给出正确的 `og:title`。代价是链接变长，因此**只在标题不超过 50 字时才写入**（`MAX_TOKEN_TITLE_LENGTH`），超长的宁可留给边缘抓取——截断后的标题会被接收端当成真标题存进缓存。占位标题（「加载中…」「分享的文章」）由 `usableShareTitle` 挡掉，不会被编进链接。
+- **标题行为什么排在 id 槽之后**：旧版客户端（已安装的 App 会通过 App Links 接管 `/a/*`）按位置解码，标题行若落在 id 槽会被当成文章 id，已读 / 正文缓存 / 稍后读就对不上。因此有标题而无 inline id 时补一行空串占位：旧解码器读到空串等于「没有 id」，自己算出的 id 与从前完全一致，只是丢掉标题。
+- **标题与信源名从哪来**：链接带标题时打开即显示；不带（旧链接、超长标题）先显示 `SHARE_PENDING_TITLE`（「加载中…」），`resolveBody` 抽完正文由 `ResolvedBody.title` 顶掉，抽取失败退到 `SHARE_FALLBACK_TITLE`（「分享的文章」）。信源名查 `sources/registry`，不认识就写「分享来源」。`withResolvedShareTitle` 只顶替占位标题，保证落进正文缓存与稍后读的不是占位符。链接里的标题是发送方给的一段文本，仅用于展示与卡片，正文与出处仍以 `originUrl` 抽取结果为准。
 - **id 怎么省的**：列表侧的条目 id 是 `lib/articleId.feedArticleId(sourceId, link)`（`<sourceId>:<djb2 哈希>`）。接收端用同一函数按原文地址算，绝大多数条目算出的 id 与发送端完全一致，已读 / 正文缓存 / 稍后读因此能对上，第 4 行也就不用出现。算不出来（例如 Google News 解码后换过地址）才写进去，且去掉冗余的 `<sourceId>:` 前缀、超过 40 字符就宁可丢掉。
 - **校验位**：紧凑载荷被截断后仍可能解出一个「看着合法」的短地址，会静默打开错误页面。首行 4 位校验对不上就当损坏处理，弹中文 `ConfirmDialog`。
 - **换新链接（salt 行）**：微信、WhatsApp 都**按 URL 缓存链接预览**，同一条链接一旦抓到过旧卡片（例如边缘卡片部署前的通用文案），之后无论怎么重发都不刷新，平台也没有公开的强制刷新入口。因此 `ReaderScreen` 每次打开分享卡片都用 `newShareSalt()`（4 位 base36 随机数）重新编 token：salt 以 `~` 行进入载荷并参与校验位，token 与 URL 随之变化，平台被迫按新 URL 重新抓取。接收端 `decodeShareToken` 直接跳过 `~` 行，文章 id 仍由 sourceId + 原文地址算出，已读 / 正文缓存 / 稍后读完全不受影响；不合规 salt（非 base36、超长）在编码时整个丢掉。**已发出的旧消息预览不会更新**，只有新发的链接才带新预览。
@@ -302,13 +307,15 @@ v2 明文（换行分隔，比 JSON 再省掉键名与引号）
 
 #### 8.6.2 社交分享卡片（边缘 worker 动态 OG 标签）
 
-微信、WhatsApp、Telegram 这类客户端是按抓到的 HTML 里的 Open Graph 标签渲染链接卡片的，而 `/a/<token>` 走 SPA 回退给出的 `index.html` 只有通用空壳标签，链接在聊天里就是一串裸地址。**卡片由 `functions/lib/shareCard.ts` 在边缘现拼**，仍然不建库、不建 API：
+微信、WhatsApp、Telegram 这类客户端是按抓到的 HTML 里的 Open Graph 标签渲染链接卡片的，而 `/a/<token>` 走 SPA 回退给出的 `index.html` 只有通用空壳标签，链接在聊天里就是一串裸地址、或者一张写着站点名的通用卡。**卡片由 `functions/lib/shareCard.ts` 在边缘现拼**，仍然不建库、不建 API。
+
+**文章级 OG 不绑死在爬虫 UA 判定上**：判定为爬虫走现拼的卡片页，判定为真人照常走 SPA，但 `index.html` 里的站点壳 meta 会按 token 改写成这篇文章的标签（`injectShareMeta`）。抓取端伪装成真实导航（微信一类客户端会带 `Sec-Fetch-*`）时因此仍拿得到文章标题，而不是「有所闻 · News Nook」。
 
 ```text
 GET /a/<token>
   │
   ├─ 爬虫（UA 命中 facebookexternalhit / Twitterbot / WhatsApp / TelegramBot / Baiduspider … ）
-  │    → decodeShareToken 拿 originUrl + sourceId
+  │    → decodeShareToken 拿 originUrl + sourceId（+ 链接里带的标题）
   │    → fetch 原文（每次 3s 超时，只读前 128KB，认 content-type / meta 里的 charset）
   │       先用浏览器 UA + 同站 Referer；没拿到标题（被拦 / 质询页）换 Googlebot UA 再试一次
   │    → 正则取 og:title | twitter:title | <title>、og:description | description、
@@ -322,7 +329,12 @@ GET /a/<token>
   │       文章卡（抓到标题）Cache-Control 3600s；
   │       兜底卡 max-age=0 + CDN-Cache-Control: no-store，失败态不被缓存钉住
   │
-  └─ 真人 → env.ASSETS.fetch(request)，SPA 回退不变
+  └─ 真人（含被误判成真人的抓取端）
+       → env.ASSETS.fetch(request)，SPA 回退不变
+       → injectShareMeta 摘掉 index.html 的 og:* / twitter:* / description / <title>，
+         按 token 补上同一组文章级标签（og:type=article、og:image 指同域端点、Vary: User-Agent）
+         只用链接里已有的信息，**不为这一跳抓上游**——真人打开分享链接不能变慢
+         token 解不出 / 不是 HTML / 多段路径 → 原样返回，站点壳 meta 不动
 
 GET /a/<token>/og.png[?src=<上游首图>]   ← 卡片首图的同域端点（任何 UA）
   │    token 可解且带 src → 转发上游首图（跟随重定向、只收 image/*、5s 超时）
@@ -330,7 +342,8 @@ GET /a/<token>/og.png[?src=<上游首图>]   ← 卡片首图的同域端点（�
   └─   Cache-Control: public, max-age=86400
 ```
 
-- **判定方式**：`wantsShareCard()` 先匹配明确的爬虫 UA。微信抓卡片与微信内置浏览器共用 `MicroMessenger` UA（抓取端还有企业微信 `wxwork`、`WeChat`、`Weixin` 变体；微博 / QQ / 钉钉的内置浏览器同理带各自 App 标识），只能再看 `Sec-Fetch-Mode`——真实导航带（内置浏览器基于 Chromium），抓取端不带；真人聊天 App 内置浏览器因此仍进 SPA。
+- **判定方式**：`wantsShareCard()` 先匹配明确的爬虫 UA。微信抓卡片与微信内置浏览器共用 `MicroMessenger` UA（抓取端还有企业微信 `wxwork`、`WeChat`、`Weixin` 变体；微博 / QQ / 钉钉的内置浏览器同理带各自 App 标识），只能再看 `Sec-Fetch-Mode`——真实导航带（内置浏览器基于 Chromium），抓取端**通常**不带；真人聊天 App 内置浏览器因此仍进 SPA。这套判定只决定「给卡片页还是给 SPA」，**不再决定预览里有没有文章标题**：抓取端带上 `Sec-Fetch-*` 或换个没见过的 UA 时，SPA 那条路的 `injectShareMeta` 兜住。改 UA 名单仍有价值（卡片页能现抓摘要与首图），但它不再是卡片正确与否的唯一开关。
+- **SPA 改写的边界**：`SHELL_META_PATTERN` 按 `property="og:*"` / `name="twitter:*"` / `name="description"` 匹配 `index.html` 里的站点级标签，连同 `<title>` 一起摘掉再补新的；`viewport`、`theme-color` 这类无关 meta 不动，`#root` 与入口脚本原样保留，SPA 行为零变化。改写后删掉 `Content-Length` / `ETag`（内容已变），并补 `Vary: User-Agent`（同址对爬虫给的是卡片页）。`index.html` 里那几行 og 标签的写法与这个正则是配套的，改一边要看另一边——`npm run test:share-og` 里有一条用**仓库真实 `index.html`** 跑的回归。
 - **社交大图卡依赖「必须带图」**：微信、WhatsApp 对没有 `og:image` 的页面几乎只出小字纯文本卡甚至不出卡。因此卡片**任何情况下都输出 og:image**：上游有首图时经同域 `GET /a/<token>/og.png?src=…` 转发（微信对跨域、防盗链、http 明文图经常直接放弃渲染；端点内跟随重定向、只收 `image/*`，失败回落品牌图）；上游没图、token 坏、抓取失败时直接给 `public/og-default.png`（1200×630 品牌图，`scripts/generate-og-default.mjs` 生成并入库）并声明 `og:image:width/height`。图片端点与卡片同在 `/a/*` 路径下，WAF 的按路径 Skip 规则一并覆盖。
 - **误判兜底**：卡片页带 `<meta http-equiv="refresh">` 指向 `?app=1`；worker 见到这个参数直接放行到 SPA，所以被误判成爬虫的真人只多一跳就回到阅读页，不会来回打转。`?app=1` 只是 query，前端仍按 pathname 解码 token，不影响打开文章；卡片自身的 `og:url` 指向不带该参数的规范地址。
 - **路由前提**：卡片能出现在聊天里的前提是 `/a/*` 请求真的进了 worker——见 8.6.1「深链可刷新」里的 `run_worker_first` 说明。若 Cloudflare WAF / Bot 拦截对微信、WhatsApp 抓取端 IP 弹质询页，爬虫同样拿不到 OG，需在仪表盘为 `/a/*` 放行已知抓取端。
@@ -348,11 +361,12 @@ GET /a/<token>/og.png[?src=<上游首图>]   ← 卡片首图的同域端点（�
   ```
 
   不要写成对 `/a/*` 全 UA 放行（真人流量也会绕过防护），更不要以为「Googlebot 已跳过 = 修好了」。
-- **「新链接也没卡」先查消息形态，别都归因缓存**：平台预览缓存只解释「旧链接刷不动」；一条**全新** URL 发出去仍没有卡片时，最常见的根因是分享面板把标题 + URL 拼成了一条**纯文本消息**（见 8.6「分享」流程里的 EXTRA_TEXT 说明），其次是卡片没有 `og:image`（微信不出大图卡）或 WAF 把社交抓取端拦在质询页。排查顺序：消息是不是裸链接 → 爬虫 UA 能否拿到带图完整卡 → WAF 事件按 UA 过滤核对。
+- **「新链接也没卡」先查消息形态，别都归因缓存**：平台预览缓存只解释「旧链接刷不动」；一条**全新** URL 发出去仍没有卡片时，最常见的根因是分享面板把标题 + URL 拼成了一条**纯文本消息**（见 8.6「分享」流程里的 EXTRA_TEXT 说明），其次是卡片没有 `og:image`（微信不出大图卡）或 WAF 把社交抓取端拦在质询页。排查顺序：消息是不是裸链接 → 爬虫 UA 能否拿到带图完整卡 → **带上 `Sec-Fetch-Mode: navigate` 再抓一次**（抓取端伪装成导航时走的是 SPA 那条路，`injectShareMeta` 必须把文章标题写进去）→ WAF 事件按 UA 过滤核对。
+- **卡片标题是站点名（「有所闻 · News Nook」）说明抓到了站点壳**：这两句与 `index.html` 的站点级 og 逐字相同，既不是「有所闻分享」也不是「<信源名> · 一篇文章」这两套兜底，说明请求根本没拿到文章级 OG——要么没进 worker（见「路由前提」），要么进了 SPA 那条路而改写没生效。
 - **平台缓存与强制刷新**：聊天预览完全依赖边缘返回的 OG；微信、WhatsApp 都按 **URL** 缓存抓取结果，且没有官方的预览刷新调试器（Facebook 的 Sharing Debugger 只服务 Facebook 家族的 og 缓存，对 WhatsApp 个人聊天不保证生效）。**已发出的旧消息卡片永远不会更新**——修好部署、改好 WAF 都救不了旧气泡，只能新发一条。App 侧的解法见 8.6.1「换新链接（salt 行）」：每次分享都是一条新 URL，平台按新 URL 重新抓取；卡片里的 `og:url` 与首图端点仍用不带 salt 的规范 token，平台按规范地址归并，不会把缓存键打散。
-- **兜底文案**：token 解不出来退到「有所闻分享」+「点击在有所闻中阅读全文」；token 可解但上游超时 / 非 200 / 非 HTML / 质询页时，标题用「<信源名> · <v1 链接里的短标题，没有则“一篇文章”>」（认识的 `sourceId` 用注册表中文名，否则用原文域名），描述补「原文来自 xxx」——观感仍是一篇文章而不是站点广告。两种兜底都带品牌图，**仍是一张完整大图卡**。兜底卡 `max-age=0` + `CDN-Cache-Control: no-store`，上游恢复后爬虫重抓立即拿到文章卡。
-- **安全**：上游标题、摘要先按 HTML 实体还原再统一 `escapeHtml`，属性边界不会被 `">` 顶开；`og:image` 与 `og.png` 端点的 `src` 只接受 http(s)，`javascript:` 之类直接丢掉；`og.png` 要求 token 可解才代转上游图，避免被当成任意图片代理。
-- **只影响 Workers 部署**：`/api/*` 的边缘代理逻辑不变；Vite 开发态没有这条路径（爬虫不会来爬 localhost），本机验证请直接跑 `npm run test:share-og`。`index.html` 里另有一套站点级默认 og 标签，只服务首页等普通页面——`/a/*` 的爬虫请求在 worker 就被接走，永远不会落到这份站点壳 meta 上。
+- **标题三级、兜底文案**：卡片标题依次取 ① 现抓到的原文 `og:title`（最新，链接里的标题可能已过时）→ ② 链接 token 里带的标题（上游超时 / 非 200 / 非 HTML / 质询页时兜住，见 8.6.1）→ ③「<信源名> · 一篇文章」（旧链接或超长标题；认识的 `sourceId` 用注册表中文名，否则用原文域名）。token 整个解不出来才退到「有所闻分享」+「点击在有所闻中阅读全文」。描述取上游摘要，没有就用「点击在有所闻中阅读全文」，再补「· 原文来自 xxx」。任何一级都**不会**落回站点通用文案。两种兜底都带品牌图，**仍是一张完整大图卡**；抓不到原文标题的卡 `max-age=0` + `CDN-Cache-Control: no-store`，上游恢复后爬虫重抓立即拿到带摘要与首图的完整卡。
+- **安全**：上游标题、摘要与**链接里带的标题**都先按 HTML 实体还原再统一 `escapeHtml`，属性边界不会被 `">` 顶开（token 是发送方可控输入，卡片页与改写后的 SPA 两条路都有转义回归）；`og:image` 与 `og.png` 端点的 `src` 只接受 http(s)，`javascript:` 之类直接丢掉；`og.png` 要求 token 可解才代转上游图，避免被当成任意图片代理。
+- **只影响 Workers 部署**：`/api/*` 的边缘代理逻辑不变；Vite 开发态没有这条路径（爬虫不会来爬 localhost），本机验证请直接跑 `npm run test:share-og`。`index.html` 里另有一套站点级默认 og 标签，只服务首页等普通页面——`/a/*` 的请求要么在 worker 就被接走，要么被 `injectShareMeta` 改写，抓取端不会落到这份站点壳 meta 上。
 
 ### 8.7 配置备份与恢复
 

--- a/functions/lib/shareCard.ts
+++ b/functions/lib/shareCard.ts
@@ -3,13 +3,16 @@
  *
  * 微信、WhatsApp、Telegram 这类客户端是按抓到的 HTML 里的 Open Graph 标签
  * 渲染链接卡片的，而 SPA 回退给出的 `index.html` 只有通用的空壳标签，
- * 于是链接在聊天里就是一串裸地址。
+ * 于是链接在聊天里就是一串裸地址、或者一张写着站点名的通用卡。
  *
- * 这里的做法仍然是无后端的：token 里已经有原文地址与信源 id，边缘节点
- * 现抓一次原文、只从 `<head>` 里取标题/摘要/首图，拼出一页极简的 OG HTML。
- * 不落库、不建 API，抓不到就退回通用文案。
+ * 这里的做法仍然是无后端的：token 里已经有原文地址、信源 id 与标题，
+ * 边缘节点再现抓一次原文、只从 `<head>` 里取标题/摘要/首图，
+ * 拼出一页极简的 OG HTML。不落库、不建 API，抓不到就用 token 里的标题。
  *
- * 只有爬虫才会拿到这页；普通浏览器继续走 SPA 回退，阅读路径完全不变。
+ * 两条路都会带上文章级 OG，**不把卡片绑死在爬虫 UA 判定上**：
+ * - 判定为爬虫 → 这份现拼的卡片 HTML（真人误判了也只多一跳 meta refresh）；
+ * - 判定为真人 → 照常走 SPA，但 `index.html` 里的站点壳 meta 会按 token
+ *   改写成这篇文章的标题（`injectShareMeta`），抓取端伪装成浏览器也认得出。
  */
 
 import {
@@ -317,20 +320,20 @@ function composeDescription(base: string | undefined, sourceName: string): strin
   return `${head}${suffix}`
 }
 
-export function renderShareCard(card: {
+interface ShareMeta {
   title: string
   description: string
   shareUrl: string
-  bounceUrl: string
   /** 必填：没有 og:image 时微信几乎不出大图卡，兜底也要给品牌图 */
   image: string
   imageWidth?: number
   imageHeight?: number
-}): string {
+}
+
+/** 卡片页与改写后的 SPA 共用这组标签，两条路给出的预览完全一致 */
+function renderShareMetaTags(card: ShareMeta): string {
   const title = escapeHtml(card.title)
   const description = escapeHtml(card.description)
-  const shareUrl = escapeHtml(card.shareUrl)
-  const bounceUrl = escapeHtml(card.bounceUrl)
   const image = escapeHtml(card.image)
   const dimensions =
     card.imageWidth && card.imageHeight
@@ -338,12 +341,10 @@ export function renderShareCard(card: {
       : ''
 
   // itemprop 三件套是微信抓卡片的旧协议，与 OG 并存输出，两代抓取端都认
-  return `<!DOCTYPE html><html lang="zh-CN" itemscope itemtype="https://schema.org/Article"><head>
-<meta charset="utf-8">
-<meta property="og:type" content="article">
+  return `<meta property="og:type" content="article">
 <meta property="og:title" content="${title}">
 <meta property="og:description" content="${description}">
-<meta property="og:url" content="${shareUrl}">
+<meta property="og:url" content="${escapeHtml(card.shareUrl)}">
 <meta property="og:image" content="${image}">${dimensions}
 <meta property="og:site_name" content="${escapeHtml(SITE_NAME)}">
 <meta name="twitter:card" content="summary_large_image">
@@ -354,36 +355,34 @@ export function renderShareCard(card: {
 <meta itemprop="description" content="${description}">
 <meta itemprop="image" content="${image}">
 <meta name="description" content="${description}">
-<title>${title} - 有所闻</title>
-<meta http-equiv="refresh" content="0;url=${bounceUrl}">
+<title>${title} - 有所闻</title>`
+}
+
+export function renderShareCard(card: ShareMeta & { bounceUrl: string }): string {
+  return `<!DOCTYPE html><html lang="zh-CN" itemscope itemtype="https://schema.org/Article"><head>
+<meta charset="utf-8">
+${renderShareMetaTags(card)}
+<meta http-equiv="refresh" content="0;url=${escapeHtml(card.bounceUrl)}">
 </head><body></body></html>
 `
 }
 
 /**
- * 命中分享深链且请求方是爬虫时返回卡片 HTML；其余情况返回 null，
- * 由 worker 继续走 SPA 回退。
+ * 拼出这篇文章的一组 OG 值。`meta` 是现抓原文的结果，抓不到就传空对象——
+ * 标题会退到 token 里带的标题，再退到「<信源名> · 一篇文章」，
+ * 任何情况下都不会落回站点通用文案。
  */
-export async function shareCardResponse(request: Request, url: URL): Promise<Response | null> {
-  if (request.method !== 'GET' && request.method !== 'HEAD') return null
-  if (!url.pathname.startsWith(SHARE_PATH_PREFIX)) return null
-  if (url.searchParams.has(SHARE_CARD_BYPASS_PARAM)) return null
-  if (!wantsShareCard(request)) return null
-
-  // 路径不成形（`/a/` 或多段）就不是分享深链，交回 SPA；token 解不出来才给通用卡片
-  const token = shareTokenFromPath(url.pathname)
-  if (!token) return null
-
-  const payload = decodeShareToken(token)
-  const meta = payload ? await fetchPageMeta(payload.originUrl) : {}
+function composeShareMeta(
+  url: URL,
+  token: string,
+  payload: SharePayload | null,
+  meta: PageMeta,
+): ShareMeta {
   const sourceName = payload ? describeSource(payload) : ''
 
   // og:url 用不带 salt 的规范 token：salt 只为换 URL 打破平台预览缓存，
   // 规范地址才是这篇文章的稳定身份，平台按 og:url 归并时不会把缓存键打散。
   const canonicalToken = payload ? encodeShareToken(payload) : token
-  const shareUrl = `${url.origin}${SHARE_PATH_PREFIX}${canonicalToken}`
-  // 逃生门要回到用户实际点开的地址（可能带 salt），token 在 pathname 上原样保留
-  const bounceUrl = `${url.origin}${url.pathname}?${SHARE_CARD_BYPASS_PARAM}=1`
 
   // og:image 必须存在且是同域 https 绝对地址：上游首图经 /a/<token>/og.png
   // 转发（防盗链、http 图、失效图都在端点内兜底），没有首图直接指品牌图。
@@ -399,22 +398,45 @@ export async function shareCardResponse(request: Request, url: URL): Promise<Res
       : {}
     : { imageWidth: OG_DEFAULT_IMAGE_WIDTH, imageHeight: OG_DEFAULT_IMAGE_HEIGHT }
 
-  // 抓到文章标题才算「文章卡」；抓不到时兜底标题也要长得像一篇文章：
-  // 「<信源名> · <v1 链接里的短标题或“一篇文章”>」，不能只剩一句站点空话
-  const articleTitle = meta.title
+  // 标题三级：现抓的原文标题 > 分享链接里带的标题 > 「<信源名> · 一篇文章」
+  const linkTitle = normalizeText(payload?.title, MAX_TITLE_LENGTH)
   const fallbackTitle = payload
-    ? `${sourceName ? `${sourceName} · ` : ''}${
-        normalizeText(payload.title, MAX_TITLE_LENGTH) ?? FALLBACK_ARTICLE_TITLE
-      }`
+    ? `${sourceName ? `${sourceName} · ` : ''}${FALLBACK_ARTICLE_TITLE}`
     : FALLBACK_TITLE
-  const html = renderShareCard({
-    title: articleTitle || fallbackTitle,
+
+  return {
+    title: meta.title || linkTitle || fallbackTitle,
     description: composeDescription(meta.description, sourceName),
-    shareUrl,
-    bounceUrl,
+    shareUrl: `${url.origin}${SHARE_PATH_PREFIX}${canonicalToken}`,
     image,
     ...dimensions,
+  }
+}
+
+/**
+ * 命中分享深链且请求方是爬虫时返回卡片 HTML；其余情况返回 null，
+ * 由 worker 继续走 SPA 回退（SPA 的 meta 由 injectShareMeta 改写）。
+ */
+export async function shareCardResponse(request: Request, url: URL): Promise<Response | null> {
+  if (request.method !== 'GET' && request.method !== 'HEAD') return null
+  if (!url.pathname.startsWith(SHARE_PATH_PREFIX)) return null
+  if (url.searchParams.has(SHARE_CARD_BYPASS_PARAM)) return null
+  if (!wantsShareCard(request)) return null
+
+  // 路径不成形（`/a/` 或多段）就不是分享深链，交回 SPA；token 解不出来才给通用卡片
+  const token = shareTokenFromPath(url.pathname)
+  if (!token) return null
+
+  const payload = decodeShareToken(token)
+  const meta = payload ? await fetchPageMeta(payload.originUrl) : {}
+  const html = renderShareCard({
+    ...composeShareMeta(url, token, payload, meta),
+    // 逃生门要回到用户实际点开的地址（可能带 salt），token 在 pathname 上原样保留
+    bounceUrl: `${url.origin}${url.pathname}?${SHARE_CARD_BYPASS_PARAM}=1`,
   })
+
+  // 抓到原文标题才算「抓成功」：摘要与首图也跟着到位，卡片不会再变
+  const crawled = Boolean(meta.title)
 
   return new Response(request.method === 'HEAD' ? null : html, {
     status: 200,
@@ -422,12 +444,67 @@ export async function shareCardResponse(request: Request, url: URL): Promise<Res
       'Content-Type': 'text/html; charset=utf-8',
       // 文章卡可以多缓存一会儿（标题不会变）；兜底卡不缓存，
       // 上游恢复后爬虫重抓立即能拿到文章级卡片，失败态不该被钉住十分钟
-      'Cache-Control': articleTitle ? 'public, max-age=3600' : 'public, max-age=0, must-revalidate',
-      ...(articleTitle ? {} : { 'CDN-Cache-Control': 'no-store' }),
+      'Cache-Control': crawled ? 'public, max-age=3600' : 'public, max-age=0, must-revalidate',
+      ...(crawled ? {} : { 'CDN-Cache-Control': 'no-store' }),
       // 同一地址对真人给的是 SPA，中间缓存不能把卡片复用过去
       Vary: 'User-Agent',
     },
   })
+}
+
+/** index.html 里的站点级 og / twitter / description 标签，改写前先摘掉 */
+const SHELL_META_PATTERN =
+  /[ \t]*<meta\b[^>]*\b(?:property="og:[^"]*"|name="(?:twitter:[^"]*|description)")[^>]*>\n?/gi
+const SHELL_TITLE_PATTERN = /[ \t]*<title\b[^>]*>[\s\S]*?<\/title>\n?/i
+const HEAD_END_PATTERN = /<\/head>/i
+
+/** 只有 HTML 才值得改写；静态资源与 404 原样放行 */
+function isHtmlResponse(response: Response): boolean {
+  return response.ok && /text\/html/i.test(response.headers.get('content-type') ?? '')
+}
+
+function withVaryUserAgent(headers: Headers): Headers {
+  const vary = headers.get('Vary')
+  if (!vary) headers.set('Vary', 'User-Agent')
+  else if (!/\buser-agent\b/i.test(vary)) headers.set('Vary', `${vary}, User-Agent`)
+  return headers
+}
+
+/**
+ * `/a/<token>` 落到 SPA 时，把 `index.html` 的站点壳 meta 换成这篇文章的 OG 标签。
+ *
+ * 为什么需要它：抓取端不总是认得出来——微信一类客户端会带上 `Sec-Fetch-*`
+ * 伪装成真实导航，UA 判定一失手，爬虫拿到的就是站点通用文案（「有所闻 · News Nook」）。
+ * 改写之后，即便判定成真人，抓到的 HTML 里也是这篇文章的标题。
+ *
+ * 只用 token 里已有的信息，不抓上游：真人打开分享链接的这一跳不能为了卡片变慢。
+ * 非 `/a/<token>`、token 解不出、不是 HTML 一律原样返回。
+ */
+export async function injectShareMeta(request: Request, url: URL, asset: Response): Promise<Response> {
+  if (request.method !== 'GET') return asset
+  if (!url.pathname.startsWith(SHARE_PATH_PREFIX)) return asset
+  const token = shareTokenFromPath(url.pathname)
+  if (!token) return asset
+  const payload = decodeShareToken(token)
+  if (!payload) return asset
+  if (!isHtmlResponse(asset)) return asset
+
+  const html = await asset.text()
+  const headers = withVaryUserAgent(new Headers(asset.headers))
+  // 长度与强校验都随改写失效，留着会让中间缓存把站点壳复用回来
+  headers.delete('content-length')
+  headers.delete('etag')
+
+  const stripped = html.replace(SHELL_META_PATTERN, '').replace(SHELL_TITLE_PATTERN, '')
+  const headEnd = stripped.search(HEAD_END_PATTERN)
+  const body =
+    headEnd < 0
+      ? html
+      : `${stripped.slice(0, headEnd)}${renderShareMetaTags(
+          composeShareMeta(url, token, payload, {}),
+        )}\n${stripped.slice(headEnd)}`
+
+  return new Response(body, { status: asset.status, statusText: asset.statusText, headers })
 }
 
 /** 首图转发比抓 head 更宽裕些：图片体积大、CDN 链路多一跳很常见 */

--- a/functions/lib/shareCard.ts
+++ b/functions/lib/shareCard.ts
@@ -480,7 +480,11 @@ function withVaryUserAgent(headers: Headers): Headers {
  * 只用 token 里已有的信息，不抓上游：真人打开分享链接的这一跳不能为了卡片变慢。
  * 非 `/a/<token>`、token 解不出、不是 HTML 一律原样返回。
  */
-export async function injectShareMeta(request: Request, url: URL, asset: Response): Promise<Response> {
+export async function injectShareMeta(
+  request: Request,
+  url: URL,
+  asset: Response,
+): Promise<Response> {
   if (request.method !== 'GET') return asset
   if (!url.pathname.startsWith(SHARE_PATH_PREFIX)) return asset
   const token = shareTokenFromPath(url.pathname)

--- a/functions/worker.ts
+++ b/functions/worker.ts
@@ -1,5 +1,5 @@
 import { onRequest } from './api/[[path]].ts'
-import { shareCardResponse, shareImageResponse } from './lib/shareCard.ts'
+import { injectShareMeta, shareCardResponse, shareImageResponse } from './lib/shareCard.ts'
 
 export interface Env {
   ASSETS?: {
@@ -41,9 +41,10 @@ export default {
     const card = await shareCardResponse(request, url)
     if (card) return card
 
-    // 4. 其余静态资源和前端 SPA 页面由 dist 静态资产服务
+    // 4. 其余静态资源和前端 SPA 页面由 dist 静态资产服务；
+    //    分享深链落到 SPA 时（含爬虫被误判成真人）再按 token 改写文章级 OG 标签
     if (env.ASSETS) {
-      return env.ASSETS.fetch(request)
+      return injectShareMeta(request, url, await env.ASSETS.fetch(request))
     }
 
     return new Response('Asset binding ASSETS not found', { status: 500 })

--- a/index.html
+++ b/index.html
@@ -14,9 +14,10 @@
     <meta name="referrer" content="no-referrer" />
     <meta name="description" content="有所闻 News Nook，直连原发媒体的沉浸式阅读器。" />
     <!--
-      首页的默认社交卡片。仅当爬虫抓站点根等普通页面时生效；
-      /a/* 分享深链在边缘 worker 就被接走（functions/lib/shareCard.ts），
-      社交爬虫拿到的是文章级卡片，永远不会落到这份站点壳 meta 上。
+      首页的默认社交卡片。仅当抓取站点根等普通页面时生效；
+      /a/* 分享深链要么在边缘 worker 就被接走、要么由 worker 按 token 把这几行
+      改写成文章级标签（functions/lib/shareCard.ts），抓取端永远不会落到这份站点壳 meta 上。
+      改这些标签的属性写法前先看 shareCard.ts 里的 SHELL_META_PATTERN，别让改写漏匹配。
     -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="有所闻" />

--- a/scripts/share-link.test.ts
+++ b/scripts/share-link.test.ts
@@ -39,20 +39,50 @@ const article: Article = {
   originUrl: 'https://sspai.com/post/12345',
 }
 
-// 1. v2 往返：打开阅读器只需要原文地址与信源 id
+// 1. v2 往返：打开阅读器需要原文地址与信源 id，标题供聊天预览卡使用
 const payload = sharePayloadFromArticle(article)
 const token = encodeShareToken(payload)
 const decoded = decodeShareToken(token)
 assert.ok(decoded, '正常 token 应能解码')
 assert.equal(decoded.originUrl, article.originUrl)
 assert.equal(decoded.sourceId, article.sourceId)
+assert.equal(decoded.title, article.title, '标题应原样往返，边缘据此拼 og:title')
 
-// 2. 中文标题、摘要、信源名都不进 token
+// 2. 只有标题进 token：摘要、信源名仍然不编码
 const plain = Buffer.from(token.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8')
-assert.ok(!/[\u4e00-\u9fff]/.test(plain), 'v2 载荷里不应出现中文')
-assert.ok(!plain.includes(article.title), '标题不得编进 token')
+assert.ok(plain.includes(`\n!${article.title}`), '标题以 ! 行编进载荷')
 assert.ok(!plain.includes(article.summary), '摘要不得编进 token')
+assert.ok(!plain.includes(article.sourceName), '信源名不得编进 token（接收端查 registry）')
 assert.ok(/^2\.[0-9a-z]{1,4}\n/.test(plain), 'v2 载荷第一行是版本号加校验位')
+
+// 2b. 标题行排在 id 槽之后：没有 inline id 时补一行空串，
+//     旧版客户端按位置解码时才不会把标题当成 id（id 错了已读/缓存都对不上）
+assert.equal(
+  plain.split('\n')[3],
+  '',
+  '标题前应留一行空的 id 槽，保证旧客户端解码出的文章 id 不变',
+)
+assert.equal(plain.split('\n')[4], `!${article.title}`, '标题行紧跟在 id 槽之后')
+
+// 2c. 超长标题宁可不编：截断的标题会被接收端当成真标题存进缓存
+const longTitle = '标'.repeat(120)
+const longTitleToken = encodeShareToken({ ...payload, title: longTitle })
+assert.equal(decodeShareToken(longTitleToken)?.title, undefined, '超长标题不进 token')
+assert.equal(longTitleToken, encodeShareToken({ ...payload, title: undefined }))
+
+// 2d. 占位标题不进 token：卡片上不能出现「加载中…」
+assert.equal(
+  sharePayloadFromArticle({ ...article, title: SHARE_PENDING_TITLE }).title,
+  undefined,
+  '占位标题不得当成真标题分享',
+)
+assert.equal(sharePayloadFromArticle({ ...article, title: SHARE_FALLBACK_TITLE }).title, undefined)
+
+// 2e. 标题里的换行会打乱行格式，编码前折成空格
+assert.equal(
+  decodeShareToken(encodeShareToken({ ...payload, title: '两行\n标题' }))?.title,
+  '两行 标题',
+)
 
 // 3. 长度上限：常见站点的分享 token 要留在一行放得下的范围内
 const lengthCases: Array<{ label: string; article: Article }> = [
@@ -267,14 +297,19 @@ assert.equal(
   '未知版本应拒绝',
 )
 
-// 12. 还原 Article：v2 没有标题时先占位，id 与列表侧算法保持一致
+// 12. 还原 Article：链接带标题就直接显示，没带（旧链接 / 超长标题）先占位，
+//     两种情况下 id 都与列表侧算法保持一致
 const opened = articleFromSharePayload(decoded)
 assert.equal(opened.sourceId, 'sspai')
 assert.equal(opened.originUrl, article.originUrl)
 assert.equal(opened.id, article.id, '省掉 id 时接收端应算出与列表侧相同的 id')
-assert.equal(opened.title, SHARE_PENDING_TITLE)
+assert.equal(opened.title, article.title, '链接里带了标题就不必再占位')
 assert.equal(opened.hasRealDate, false)
-assert.ok(isPendingShareTitle(opened.title))
+
+const untitled = articleFromSharePayload(decodeShareToken(longTitleToken)!)
+assert.equal(untitled.id, article.id, '不带标题的链接算出的 id 不变')
+assert.equal(untitled.title, SHARE_PENDING_TITLE)
+assert.ok(isPendingShareTitle(untitled.title))
 
 const fromLegacy = articleFromSharePayload(legacy)
 assert.equal(fromLegacy.title, '国产大模型价格战再起')
@@ -294,9 +329,10 @@ assert.equal(
 )
 
 // 13. 正文抽取补回真标题后才落盘；已有真标题的文章不被覆盖
-assert.equal(withResolvedShareTitle(opened, '真标题').title, '真标题')
-assert.equal(withResolvedShareTitle(opened, '   ').title, SHARE_PENDING_TITLE)
+assert.equal(withResolvedShareTitle(untitled, '真标题').title, '真标题')
+assert.equal(withResolvedShareTitle(untitled, '   ').title, SHARE_PENDING_TITLE)
 assert.equal(withResolvedShareTitle(article, '别的标题').title, article.title)
+assert.equal(withResolvedShareTitle(opened, '抽取到的标题').title, article.title)
 
 // 14. 缓存里的占位标题不该被当成真标题再回填一遍
 assert.equal(usableShareTitle('真标题'), '真标题')

--- a/scripts/share-link.test.ts
+++ b/scripts/share-link.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { feedArticleId } from '../src/lib/articleId'
 import {
   MAX_SHARE_TOKEN_LENGTH,
+  MAX_TOKEN_TITLE_LENGTH,
   SHARE_LINK_ORIGIN,
   SHARE_FALLBACK_TITLE,
   SHARE_PATH_PREFIX,
@@ -65,7 +66,7 @@ assert.equal(
 assert.equal(plain.split('\n')[4], `!${article.title}`, '标题行紧跟在 id 槽之后')
 
 // 2c. 超长标题宁可不编：截断的标题会被接收端当成真标题存进缓存
-const longTitle = '标'.repeat(120)
+const longTitle = '标'.repeat(MAX_TOKEN_TITLE_LENGTH + 1)
 const longTitleToken = encodeShareToken({ ...payload, title: longTitle })
 assert.equal(decodeShareToken(longTitleToken)?.title, undefined, '超长标题不进 token')
 assert.equal(longTitleToken, encodeShareToken({ ...payload, title: undefined }))

--- a/scripts/share-og.test.ts
+++ b/scripts/share-og.test.ts
@@ -1,19 +1,36 @@
 /**
- * 分享深链 `/a/<token>` 的社交卡片：只有爬虫拿 OG HTML，真人仍走 SPA。
+ * 分享深链 `/a/<token>` 的社交卡片：爬虫拿现拼的 OG HTML，真人仍走 SPA，
+ * 但两条路给出的 og:title 都是**这篇文章**的标题。
  *
  * 大图卡三要素在这里回归：任何爬虫 UA 都必须拿到
  * ① 完整 OG + 微信 itemprop 标签；② 永远存在的 og:image（上游没图给品牌兜底图）；
  * ③ 文章化的标题/摘要——绝不能是 SPA 壳或站点通用文案。
+ *
+ * 抓取端不总认得出来（微信一类客户端会带 `Sec-Fetch-*` 伪装成真实导航），
+ * 所以「落到 SPA 的 /a/<token> 也必须带文章级 OG」同样是硬性要求。
  */
 
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 
 import worker, { type Env } from '../functions/worker.ts'
 import { encodeShareToken } from '../src/lib/shareToken.ts'
 
-/** 与 index.html 的通用 meta 保持一致：爬虫一旦拿到这段文案，聊天里就是「站点壳」卡片 */
+/** 与 index.html 的站点级 meta 保持一致：抓取端拿到这段文案，聊天里就是「站点壳」卡片 */
+const SITE_SHELL_TITLE = '有所闻 · News Nook'
 const SITE_SHELL_DESCRIPTION = '有所闻 News Nook，直连原发媒体的沉浸式阅读器。'
-const SPA_SHELL = `<!doctype html><html><head><title>有所闻 · News Nook</title><meta name="description" content="${SITE_SHELL_DESCRIPTION}" /></head><body><div id="root"></div></body></html>`
+const SPA_SHELL = `<!doctype html><html lang="zh-CN"><head>
+    <meta charset="UTF-8" />
+    <meta name="description" content="${SITE_SHELL_DESCRIPTION}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="有所闻" />
+    <meta property="og:title" content="${SITE_SHELL_TITLE}" />
+    <meta property="og:description" content="${SITE_SHELL_DESCRIPTION}" />
+    <meta property="og:url" content="https://news.aizeek.com/" />
+    <meta property="og:image" content="https://news.aizeek.com/og-default.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <title>${SITE_SHELL_TITLE}</title>
+  </head><body><div id="root"></div><script type="module" src="/assets/main.js"></script></body></html>`
 /** 品牌兜底图的假字节，静态资产 mock 用 */
 const BRAND_PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
 
@@ -35,9 +52,17 @@ const WHATSAPP_UA = 'WhatsApp/2.23.20.0'
 const BROWSER_UA =
   'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36'
 
+/** 旧链接：v2 早期的 token 不带标题，边缘只能靠现抓原文 */
 const token = encodeShareToken({
   sourceId: 'sspai',
   originUrl: 'https://sspai.com/post/12345',
+})
+/** 当前 App 发出的链接：标题编在 token 里，边缘不依赖上游也能拼出文章标题 */
+const TITLED_ARTICLE = '国产大模型价格战再起'
+const titledToken = encodeShareToken({
+  sourceId: 'sspai',
+  originUrl: 'https://sspai.com/post/12345',
+  title: TITLED_ARTICLE,
 })
 /** 上游没图时卡片应指向的同域图片端点（品牌兜底在端点内回落） */
 const OG_IMAGE_ENDPOINT = `https://news.aizeek.com/a/${token}/og.png`
@@ -95,7 +120,27 @@ function assertFullCard(html: string, context: string): void {
   assert.match(html, /<meta itemprop="description" content="[^"]+">/, `${context}: 微信 itemprop description`)
   assert.match(html, /<meta itemprop="image" content="https:\/\/[^"]+">/, `${context}: 微信 itemprop image`)
   assert.ok(!html.includes('id="root"'), `${context}: 不得是 SPA 空壳`)
+  assertNoSiteShellMeta(html, context)
+}
+
+/** 分享深链的任何响应都不许再出现站点级通用文案 */
+function assertNoSiteShellMeta(html: string, context: string): void {
   assert.ok(!html.includes(SITE_SHELL_DESCRIPTION), `${context}: 不得是站点通用文案`)
+  assert.ok(
+    !html.includes(`content="${SITE_SHELL_TITLE}"`),
+    `${context}: og:title 不得是站点名「${SITE_SHELL_TITLE}」`,
+  )
+}
+
+/** 真人（含被误判成真人的抓取端）应拿到 SPA：React 挂载点与入口脚本都在 */
+function assertSpaDelivered(html: string, context: string): void {
+  assert.ok(html.includes('id="root"'), `${context}: 应是 SPA 页面`)
+  assert.ok(html.includes('src="/assets/main.js"'), `${context}: SPA 入口脚本不得被改写掉`)
+  assert.ok(!html.includes('http-equiv="refresh"'), `${context}: 真人不该被再跳一次`)
+}
+
+function ogTitle(html: string): string | undefined {
+  return /<meta property="og:title" content="([^"]*)">/.exec(html)?.[1]
 }
 
 console.log('--- 测试 1: 爬虫 UA 拿到带文章信息的 OG 卡片 ---')
@@ -213,18 +258,96 @@ await withUpstream(
 )
 console.log('✓ 质询页过滤测试通过')
 
-console.log('--- 测试 2: 普通浏览器 UA 仍走 SPA 回退 ---')
+console.log('--- 测试 2: 普通浏览器 UA 仍走 SPA，但 meta 换成这篇文章 ---')
 await withUpstream(
   () => htmlPage('<html><head><title>不该被抓</title></head></html>'),
   async (visited) => {
-    const res = await worker.fetch(request(`/a/${token}`, BROWSER_UA), env, ctx)
+    const res = await worker.fetch(request(`/a/${titledToken}`, BROWSER_UA), env, ctx)
     const html = await res.text()
-    assert.equal(html, SPA_SHELL, '真人应拿到 SPA 空壳')
-    assert.ok(!html.includes('og:title'), '真人页面不应带卡片标签')
+    assertSpaDelivered(html, '真人访问分享深链')
     assert.equal(visited.length, 0, '真人访问不应触发服务端抓原文')
+    // 站点壳 meta 被换成文章级标签：抓取端伪装成浏览器时也看得到这篇文章
+    assert.equal(ogTitle(html), TITLED_ARTICLE)
+    assertNoSiteShellMeta(html, '改写后的 SPA')
+    assert.match(html, /<title>国产大模型价格战再起 - 有所闻<\/title>/)
+    assert.equal(
+      (html.match(/<meta property="og:title"/g) ?? []).length,
+      1,
+      '站点壳的 og:title 应被摘掉，不能与文章标签并存',
+    )
+    assert.match(html, /<meta property="og:type" content="article">/)
+    assert.match(res.headers.get('vary') ?? '', /User-Agent/i, '同址两种响应，缓存必须按 UA 分开')
   },
 )
 console.log('✓ 非爬虫 UA 测试通过')
+
+console.log('--- 测试 2a: 抓取端带上 Sec-Fetch 伪装成导航，仍拿得到文章标题 ---')
+await withUpstream(
+  () => htmlPage('<html><head><title>不该被抓</title></head></html>'),
+  async (visited) => {
+    for (const ua of [
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 MicroMessenger/8.0.42',
+      'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 wxwork/4.1.20',
+      // 完全不认识的抓取端：UA 判定必然失手，也不能落回站点壳
+      'Mozilla/5.0 (compatible; SomeUnknownPreviewBot/1.0)',
+    ]) {
+      const res = await worker.fetch(
+        request(`/a/${titledToken}`, ua, {
+          headers: { 'Sec-Fetch-Mode': 'navigate', 'Sec-Fetch-Dest': 'document' },
+        }),
+        env,
+        ctx,
+      )
+      const html = await res.text()
+      assert.equal(ogTitle(html), TITLED_ARTICLE, `伪装成导航的抓取端应拿到文章标题：${ua}`)
+      assertNoSiteShellMeta(html, `伪装成导航的抓取端 ${ua}`)
+      assertSpaDelivered(html, `伪装成导航的抓取端 ${ua}`)
+    }
+    assert.equal(visited.length, 0, '这一跳仍不该为了卡片去抓上游，真人打开不能变慢')
+  },
+)
+console.log('✓ Sec-Fetch 伪装测试通过')
+
+console.log('--- 测试 2b: 不带标题的旧链接落到 SPA 时，兜底也像一篇文章 ---')
+await withUpstream(
+  () => htmlPage('<html><head><title>不该被抓</title></head></html>'),
+  async () => {
+    const html = await worker
+      .fetch(request(`/a/${token}`, BROWSER_UA), env, ctx)
+      .then((r) => r.text())
+    assert.equal(ogTitle(html), '少数派 · 一篇文章', '旧链接兜底标题仍带信源名')
+    assertNoSiteShellMeta(html, '旧链接改写后的 SPA')
+    // 卡片必带图：SPA 改写同样指向同域图片端点（端点内回落品牌图）
+    assert.ok(html.includes(`<meta property="og:image" content="${OG_IMAGE_ENDPOINT}">`))
+  },
+)
+console.log('✓ 旧链接 SPA 兜底测试通过')
+
+console.log('--- 测试 2c: 用仓库里真实的 index.html 验证改写不漏匹配 ---')
+{
+  const realShell = readFileSync(new URL('../index.html', import.meta.url), 'utf8')
+  const realEnv: Env = {
+    ASSETS: {
+      fetch: async () =>
+        new Response(realShell, { status: 200, headers: { 'Content-Type': 'text/html' } }),
+    },
+  }
+  await withUpstream(
+    () => htmlPage('<html></html>'),
+    async () => {
+      const html = await worker
+        .fetch(request(`/a/${titledToken}`, BROWSER_UA), realEnv, ctx)
+        .then((r) => r.text())
+      assert.equal(ogTitle(html), TITLED_ARTICLE, '真实站点壳的 og:title 应被换掉')
+      assertNoSiteShellMeta(html, '真实 index.html 改写后')
+      assert.ok(!html.includes('content="website"'), 'og:type 应从 website 变成 article')
+      assert.ok(html.includes('id="root"'), 'React 挂载点必须保留')
+      assert.ok(html.includes('name="viewport"'), '与卡片无关的 meta 不该被误删')
+      assert.ok(html.includes('name="theme-color"'), '主题色 meta 不该被误删')
+    },
+  )
+}
+console.log('✓ 真实 index.html 改写测试通过')
 
 console.log('--- 测试 3: 微信 UA 按 Sec-Fetch 区分抓取与真人导航 ---')
 const WECHAT_UA =
@@ -242,7 +365,8 @@ await withUpstream(
       env,
       ctx,
     )
-    assert.equal(await navigated.text(), SPA_SHELL, '微信内置浏览器的真实导航应进 SPA')
+    assertSpaDelivered(await navigated.clone().text(), '微信内置浏览器的真实导航')
+    assert.ok(!(await navigated.text()).includes('微信抓到的标题'), '真实导航不该现抓上游')
 
     // 抓取端 UA 变体：企业微信 / WeChat / Weixin / 微博 / QQ / 钉钉也要能拿到文章级卡片
     for (const variant of [
@@ -272,12 +396,14 @@ await withUpstream(
         env,
         ctx,
       )
-      assert.equal(await res.text(), SPA_SHELL, `内置浏览器真实导航应进 SPA：${variant}`)
+      assertSpaDelivered(await res.text(), `内置浏览器真实导航：${variant}`)
     }
 
     // 真人在微信里被误判成爬虫后，逃生门 ?app=1 必须直达 SPA，pathname 上仍有 token
     const escaped = await worker.fetch(request(`/a/${token}?app=1`, WECHAT_UA), env, ctx)
-    assert.equal(await escaped.text(), SPA_SHELL, '?app=1 必须直达 SPA，由前端解码 token 进阅读器')
+    const escapedHtml = await escaped.text()
+    assertSpaDelivered(escapedHtml, '?app=1 逃生门')
+    assert.ok(!escapedHtml.includes('微信抓到的标题'), '逃生门这一跳不该现抓上游')
   },
 )
 console.log('✓ 微信 UA 分流测试通过')
@@ -314,7 +440,7 @@ await withUpstream(
       env,
       ctx,
     )
-    assert.equal(await followed.text(), SPA_SHELL, '跟随 refresh 后应落到 SPA，而不是再来一张卡片')
+    assertSpaDelivered(await followed.text(), '跟随 refresh 后应落到 SPA，而不是再来一张卡片')
   },
 )
 console.log('✓ meta refresh 逃生门测试通过')
@@ -397,6 +523,33 @@ await withUpstream(
 )
 console.log('✓ 抓取端 UA 回归测试通过')
 
+console.log('--- 测试 5c: 上游抓不到时用链接里带的标题，不再退到「一篇文章」---')
+await withUpstream(
+  () => {
+    throw new Error('upstream down')
+  },
+  async () => {
+    const html = await worker
+      .fetch(request(`/a/${titledToken}`, WHATSAPP_UA), env, ctx)
+      .then((r) => r.text())
+    assert.equal(ogTitle(html), TITLED_ARTICLE, '反爬拦住上游时，标题仍来自分享链接')
+    assert.match(html, /点击在有所闻中阅读全文 · 原文来自 少数派/)
+    assertFullCard(html, '链接标题兜底卡')
+  },
+)
+
+console.log('--- 测试 5d: 抓得到原文时以原文标题为准（链接里的标题可能已过时）---')
+await withUpstream(
+  () => htmlPage('<html><head><meta property="og:title" content="原文改过的标题"></head></html>'),
+  async () => {
+    const html = await worker
+      .fetch(request(`/a/${titledToken}`, WHATSAPP_UA), env, ctx)
+      .then((r) => r.text())
+    assert.equal(ogTitle(html), '原文改过的标题')
+  },
+)
+console.log('✓ 链接标题优先级测试通过')
+
 console.log('--- 测试 6: 上游注入的 XSS 载荷被转义 ---')
 await withUpstream(
   () =>
@@ -421,6 +574,35 @@ await withUpstream(
   },
 )
 console.log('✓ XSS 转义测试通过')
+
+console.log('--- 测试 6b: 链接里带的标题同样只当文本，卡片与 SPA 都要转义 ---')
+{
+  const evilToken = encodeShareToken({
+    sourceId: 'sspai',
+    originUrl: 'https://sspai.com/post/12345',
+    title: '"><script>alert(1)</script>',
+  })
+  await withUpstream(
+    () => {
+      throw new Error('upstream down')
+    },
+    async () => {
+      for (const [context, ua, headers] of [
+        ['卡片', WHATSAPP_UA, {}],
+        ['改写后的 SPA', BROWSER_UA, {}],
+      ] as const) {
+        const html = await worker
+          .fetch(request(`/a/${evilToken}`, ua, { headers }), env, ctx)
+          .then((r) => r.text())
+        assert.ok(!html.includes('<script>alert(1)'), `${context}: 链接标题里的脚本必须被转义`)
+        const titleMeta = /<meta property="og:title" content="([^"]*)">/.exec(html)
+        assert.ok(titleMeta, `${context}: og:title 仍应是一条完整的 meta`)
+        assert.ok(!titleMeta[1].includes('<'), `${context}: content 里不得残留原始尖括号`)
+      }
+    },
+  )
+}
+console.log('✓ 链接标题转义测试通过')
 
 console.log('--- 测试 7: GBK 页面标题不乱码，非 HTML 上游直接放弃 ---')
 {
@@ -515,10 +697,14 @@ await withUpstream(
   () => htmlPage('<html></html>'),
   async (visited) => {
     const home = await worker.fetch(request('/', WHATSAPP_UA), env, ctx)
-    assert.equal(await home.text(), SPA_SHELL, '首页对爬虫也只给 SPA')
+    assert.equal(await home.text(), SPA_SHELL, '首页对爬虫也只给 SPA，站点级 meta 原样保留')
 
     const nested = await worker.fetch(request(`/a/${token}/extra`, WHATSAPP_UA), env, ctx)
     assert.equal(await nested.text(), SPA_SHELL, '多段路径不是分享深链')
+
+    // token 解不出来时无从改写，SPA 原样返回（前端会弹中文提示）
+    const broken = await worker.fetch(request('/a/not-a-valid-token', BROWSER_UA), env, ctx)
+    assert.equal(await broken.text(), SPA_SHELL, '坏 token 的 SPA 不改写')
     assert.equal(visited.length, 0)
   },
 )

--- a/src/lib/shareLink.ts
+++ b/src/lib/shareLink.ts
@@ -51,13 +51,19 @@ function clip(value: string, max: number): string {
   return trimmed.length > max ? trimmed.slice(0, max) : trimmed
 }
 
-/** 从当前文章取出可分享的最小字段 */
+/**
+ * 从当前文章取出可分享的最小字段。
+ * 标题也带上：聊天预览卡靠它显示「这篇文章」的名字，边缘抓不到原文时不至于
+ * 退回通用文案（占位标题不算真标题，超长标题由 encodeShareToken 自行丢弃）。
+ */
 export function sharePayloadFromArticle(article: Article): SharePayload {
   const id = clip(article.id, MAX_ID_LENGTH)
+  const title = usableShareTitle(article.title)
   return {
     originUrl: article.originUrl,
     sourceId: clip(article.sourceId, MAX_ID_LENGTH),
     ...(id ? { id } : {}),
+    ...(title ? { title } : {}),
   }
 }
 

--- a/src/lib/shareLink.ts
+++ b/src/lib/shareLink.ts
@@ -27,6 +27,7 @@ import type { Article } from './types'
 
 export {
   MAX_SHARE_TOKEN_LENGTH,
+  MAX_TOKEN_TITLE_LENGTH,
   SHARE_LINK_HOST,
   SHARE_LINK_ORIGIN,
   SHARE_PATH_PREFIX,

--- a/src/lib/shareToken.ts
+++ b/src/lib/shareToken.ts
@@ -16,7 +16,8 @@
  * 第 1 行  "2.<校验位>"：版本号 + 其余内容的短哈希
  * 第 2 行  sourceId
  * 第 3 行  原文地址，https:// 前缀省略不写
- * 第 4 行  可选 id；以 ':' 开头表示补回 `<sourceId>:` 前缀
+ * 第 4 行  可选 id；以 ':' 开头表示补回 `<sourceId>:` 前缀（有标题时即使没有 id 也占一行空串）
+ * 第 5 行  可选标题；以 '!' 开头，见下
  * 末   行  可选 salt；以 '~' 开头，解码时忽略
  * ```
  *
@@ -29,11 +30,20 @@
  * salt 不参与打开文章——接收端解码时直接跳过 '~' 行，文章 id 仍由
  * sourceId + 原文地址算出，已读、缓存、稍后读都对得上。
  *
- * 标题打开后由正文抽取补上（在此之前显示占位），信源名从 registry 查。
- * 绝大多数条目的 id 就是 `<sourceId>:<原文地址哈希>`（见 lib/articleId），
- * 接收端能自己算出来，第 4 行因此通常不出现。
+ * 标题行存在的理由：聊天里的链接预览卡由边缘 worker 现拼（functions/lib/shareCard.ts），
+ * 卡片标题原本只能靠边缘现抓一次原文。抓取被反爬拦住、或抓取端被误判成真人时，
+ * 卡片就只剩「一篇文章」甚至站点通用文案，对方看不出分享的是哪一篇。
+ * 分享时 App 手里本来就有真标题，编进 token 后边缘不依赖上游也能拼出正确的 og:title。
+ * 代价是链接变长（中文一字三字节），因此只在标题不超过
+ * `MAX_TOKEN_TITLE_LENGTH` 时才写入，超长的宁可留给边缘抓取。
  *
- * v1 的 JSON 载荷仍然可解码，旧链接不会失效。
+ * 标题缺席时（旧链接、超长标题）打开后仍由正文抽取补上（在此之前显示占位），
+ * 信源名从 registry 查。绝大多数条目的 id 就是 `<sourceId>:<原文地址哈希>`
+ * （见 lib/articleId），接收端能自己算出来，第 4 行因此通常是空串或不出现。
+ *
+ * v1 的 JSON 载荷仍然可解码，旧链接不会失效；反过来，带标题的新 token 在旧版
+ * 客户端里也只会丢掉标题（标题行前的空 id 行让旧解码器的位置槽仍然对齐），
+ * 打开的仍是同一篇。
  */
 
 import { feedArticleId, hashId } from './articleId'
@@ -50,8 +60,11 @@ const LEGACY_TOKEN_VERSION = 1
 
 /** 超出一律视为被篡改或被拼接，直接拒绝；仍按 v1 的宽度留着，旧链接才打得开 */
 export const MAX_SHARE_TOKEN_LENGTH = 2048
-/** 常见文章（网易 / 公众号 / RSS）编出来的 v2 token 应落在这个长度内 */
-export const SHARE_TOKEN_TYPICAL_LIMIT = 120
+/**
+ * 常见文章（网易 / 公众号 / RSS）编出来的 v2 token 应落在这个长度内。
+ * 带上中文标题后比不带标题时长了一截，但仍只有 v1 的一半左右。
+ */
+export const SHARE_TOKEN_TYPICAL_LIMIT = 240
 
 export const MAX_ID_LENGTH = 256
 
@@ -65,12 +78,20 @@ const MAX_INLINE_ID_LENGTH = 40
 const CHECKSUM_LENGTH = 4
 /** salt 行前缀：以它开头的行在解码时整行跳过 */
 const SALT_LINE_PREFIX = '~'
+/** 标题行前缀：与 salt 行一样按标记解析，不占位置槽 */
+const TITLE_LINE_PREFIX = '!'
+/**
+ * 写进 token 的标题上限。中文一字三字节，base64 再膨胀 1/3，
+ * 超过这个长度的标题写进去会把链接撑得太长，宁可交给边缘现抓原文。
+ */
+export const MAX_TOKEN_TITLE_LENGTH = 50
 /** salt 只是换 URL 用的随机数，太长白占字符 */
 const MAX_SALT_LENGTH = 8
 
 /**
  * 分享 token 里可能出现的字段。
- * v2 只保证 `originUrl` 与 `sourceId`；其余都是 v1 链接的遗留信息。
+ * v2 只保证 `originUrl` 与 `sourceId`；`sourceName` / `summary` / `publishedAt`
+ * 是 v1 链接的遗留信息。
  */
 export interface SharePayload {
   /** 出版社地址：接收方抽取正文与「浏览器核对原文」都用它 */
@@ -78,6 +99,7 @@ export interface SharePayload {
   sourceId: string
   /** 无法由 sourceId + 原文地址推出时才带 */
   id?: string
+  /** 不超过 MAX_TOKEN_TITLE_LENGTH 时才编进 v2 链接，供边缘拼卡片标题 */
   title?: string
   sourceName?: string
   summary?: string
@@ -156,9 +178,19 @@ function compactArticleId(payload: SharePayload): string | null {
   if (id === feedArticleId(payload.sourceId, payload.originUrl)) return null
   const prefix = `${payload.sourceId}:`
   const short = id.startsWith(prefix) ? `:${id.slice(prefix.length)}` : id
-  // '~' 开头的行是 salt 的记号，撞上的 id 宁可丢掉让接收端自己算
-  if (short.startsWith(SALT_LINE_PREFIX)) return null
+  // '~' / '!' 开头的行是 salt 与标题的记号，撞上的 id 宁可丢掉让接收端自己算
+  if (short.startsWith(SALT_LINE_PREFIX) || short.startsWith(TITLE_LINE_PREFIX)) return null
   return short.length > MAX_INLINE_ID_LENGTH ? null : short
+}
+
+/**
+ * 能写进 token 的标题：折掉换行与多余空白（换行会打乱行格式），
+ * 超长则整个丢掉——截断后的标题会被接收端当成真标题存进缓存。
+ */
+function compactTitle(title: string | undefined): string | null {
+  const text = title?.replace(/\s+/g, ' ').trim()
+  if (!text || text.length > MAX_TOKEN_TITLE_LENGTH) return null
+  return text
 }
 
 function checksum(body: string): string {
@@ -182,7 +214,12 @@ function sanitizeSalt(salt: string | undefined): string | null {
 export function encodeShareToken(payload: SharePayload, options?: { salt?: string }): string {
   const lines = [payload.sourceId, compactOriginUrl(payload.originUrl)]
   const inlineId = compactArticleId(payload)
+  const title = compactTitle(payload.title)
+  // 标题行必须排在 id 槽之后：没有 inline id 时补一行空串，旧版客户端按位置
+  // 解码时才不会把标题当成 id（id 错了会让已读 / 缓存 / 稍后读对不上）
   if (inlineId) lines.push(inlineId)
+  else if (title) lines.push('')
+  if (title) lines.push(`${TITLE_LINE_PREFIX}${title}`)
   const salt = sanitizeSalt(options?.salt)
   if (salt) lines.push(`${SALT_LINE_PREFIX}${salt}`)
   const body = lines.join('\n')
@@ -197,8 +234,19 @@ function decodeV2(text: string): SharePayload | null {
   const body = text.slice(headerEnd + 1)
   if (text.slice(1, headerEnd) !== `.${checksum(body)}`) return null
 
-  // salt 行只为换 URL 而存在，校验完整性之后就与打开文章无关
-  const lines = body.split('\n').filter((line) => !line.startsWith(SALT_LINE_PREFIX))
+  // 标记行（salt / 标题）先摘出去，剩下的才按位置解析：
+  // salt 只为换 URL 而存在，校验完整性之后就与打开文章无关
+  const lines: string[] = []
+  let title: string | null = null
+  for (const line of body.split('\n')) {
+    if (line.startsWith(SALT_LINE_PREFIX)) continue
+    if (line.startsWith(TITLE_LINE_PREFIX)) {
+      title ??= nonEmptyString(line.slice(TITLE_LINE_PREFIX.length), MAX_TITLE_LENGTH)
+      continue
+    }
+    lines.push(line)
+  }
+
   const sourceId = nonEmptyString(lines[0], MAX_ID_LENGTH)
   const originUrl = safeHttpUrl(expandOriginUrl((lines[1] ?? '').trim()))
   if (!sourceId || !originUrl) return null
@@ -209,6 +257,7 @@ function decodeV2(text: string): SharePayload | null {
     originUrl,
     sourceId,
     ...(id && id.length <= MAX_ID_LENGTH ? { id } : {}),
+    ...(title ? { title } : {}),
   }
 }
 

--- a/src/screens/ReaderScreen.tsx
+++ b/src/screens/ReaderScreen.tsx
@@ -698,7 +698,7 @@ export function ReaderScreen({
       ? translated.title
       : resolvedTitle || pendingTitle
 
-  /** 分享深链进来的文章标题只是占位；收藏时存正文抽取补回的真标题 */
+  /** 分享深链进来的文章标题只是占位；收藏与再分享都用正文抽取补回的真标题 */
   const laterArticle = useMemo(
     () => withResolvedShareTitle(article, resolvedTitle),
     [article, resolvedTitle],
@@ -931,12 +931,15 @@ export function ReaderScreen({
 
   /**
    * 分享主链接：站内短链，对方点开在网页版里读全文。
-   * token 只带原文地址与信源 id，标题由对方抽取正文时自己补。
+   * token 带原文地址、信源 id 与标题（标题供聊天预览卡使用；深链进来的文章
+   * 用正文抽取补齐后的真标题，不把「加载中…」编进链接）。
    */
   const shareUrl = useMemo(() => {
     if (!originUrl) return ''
-    return buildShareUrl(sharePayloadFromArticle({ ...article, originUrl }), { salt: shareSalt })
-  }, [article, originUrl, shareSalt])
+    return buildShareUrl(sharePayloadFromArticle({ ...laterArticle, originUrl }), {
+      salt: shareSalt,
+    })
+  }, [laterArticle, originUrl, shareSalt])
 
   const originHost = useMemo(() => {
     if (!originUrl) return undefined


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

分享文章后聊天里已有链接预览大卡，但标题/描述是站点通用文案（「有所闻 · News Nook」），看不出分享的是哪一篇。

根因：微信等抓取端若带上 `Sec-Fetch-Mode: navigate`，会被 `wantsShareCard()` 当成真人，`/a/<token>` 落到 SPA 的 `index.html`，社交平台抓到的是站点级 OG，而不是文章级卡片。

## 改动

- `/a/<token>` 回退到 SPA 时，按 token **改写** `index.html` 的 `og:*` / `twitter:*` / `<title>` 等，使爬虫即使被当成浏览器也能拿到文章标题。
- v2 token 可选携带标题行（`!` 前缀），上游抓不到时仍能拼出文章级 `og:title`；旧 token 兼容。
- 卡片标题优先级：现抓原文标题 > 链接内标题 >「&lt;信源名&gt; · 一篇文章」，不再落回站点广告语。
- 同步 `docs/architecture.md` 8.6 / 8.6.1 / 8.6.2。

主链接仍是站内 `/a/<token>`；salt、品牌兜底图、Backendless 不变。

## 验证

- `npm run test:share-og` / `test:share-link` / `test:share-article` / `test:cf-proxy` / `app-deep-link` 通过
- `npx tsc -b` 通过；lint 无新增 warning
- 新增：带 `Sec-Fetch-Mode: navigate` 的微信 UA 仍返回文章级 `og:title`；真实 `index.html` 改写回归

## 注意

- 微信/WhatsApp **按 URL 缓存**预览，已发出的旧气泡不会刷新，需重新分享（新 salt）。
- 未在真机微信做端到端回归。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12d3c5ca-f514-4c8b-9f59-bf1e4016010b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12d3c5ca-f514-4c8b-9f59-bf1e4016010b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

