### PR TITLE
docs+feat(wechat): 取流方案调研与列表/正文分离

### DIFF
--- a/docs/news-sources.md
+++ b/docs/news-sources.md
@@ -166,14 +166,19 @@ WebView 观察页面的网络、DOM、MSE 与 DRM 信号；接口或观察失败
   `normalizeWechatAlbumUrl` 归一成 JSON 列表入口（`addCustomSource` 自动定 kind）。
   合集只含作者手工归档的文章，不等于全量文章流。
 
-镜像 feed 结构（2026-08-25 实测）：标准 RSS 2.0，`content:encoded` 自带**完整正文**，
-图片经镜像 `img-proxy` 中转（绕开 mmbiz.qpic.cn Referer 防盗链）。feed 自带全文时
-**正文主路径 = feed 全文**（`isSubstantialHtml` 通过，站内直接渲染）；已知噪声由
+镜像 feed 结构（2026-08-25 实测）：标准 RSS 2.0，`content:encoded` 自带**完整正文**
+（占 feed 体积 98–99%，`<description>` 近乎为空），图片经镜像 `img-proxy` 中转
+（绕开 mmbiz.qpic.cn Referer 防盗链）。**信息流与正文分离**（2026-08-25 起）：
+`parseWechatMirrorFeed` 只用全文派生摘要（220 字）与封面（首图），随后丢弃
+`contentHtml`，列表条目只含元数据；正文一律走下方直连路径按需获取。噪声由
 `cleanWechatArticleHtml` 剥离：头部「原创 作者 日期 地点」meta 行、尾部
 「跳转微信打开」link-proxy 链接、隐藏的 `<mp-style-type>`（微信编辑器产物，
-原文页里同样存在）。
+原文页里同样存在）。传输层实测：实例支持 gzip（2.9MB → 216KB wire）与
+`ETag`/`If-None-Match` → 304（条件请求接入为 follow-up），不支持 Range；
+名称检索可用实例目录 `/list/all`（77KB，名称 → feed hash 全量锚点）。完整比选
+过程见 `docs/superpowers/specs/2026-08-25-wechat-account-stream-research.md`。
 
-直连正文路径（feed 缺全文 / 合集条目 / 旧文缓存被逐出时）：`resolveBody` 抓
+直连正文路径（镜像列表条目 / 合集条目 / 旧文缓存被逐出时）：`resolveBody` 抓
 `mp.weixin.qq.com` 文章页，由 `extractWechatBodyHtml` 取 `#js_content`
 （.rich_media_content）——容器带 `visibility: hidden` 内联样式、图片全部 `data-src`
 懒加载（由 `normalizeContentImages` 统一提升并加 `referrerpolicy="no-referrer"`），
@@ -233,7 +238,9 @@ WebView 观察页面的网络、DOM、MSE 与 DRM 信号；接口或观察失败
 | Datawhale（镜像可用） | 教程/训练营向，深度解读密度低 |
 | 数英 digitaling.com | `/feed` 返回 HTML（无 RSS）；内容偏营销创意案例，AI 深度评测密度低，需专用解析性价比不足 |
 | 站酷 zcool.com.cn | 列表页为阿里云 WAF JS 挑战壳（无 JS 客户端拿不到内容），且以作品图集为主非图文长文 |
-| sogou 微信搜索 / feeddd / RSSHub 微信路由 | 搜狗验证码墙；feeddd 项目已停更；RSSHub 微信路由长期不可用——均不满足「稳定公开聚合入口」 |
+| sogou 微信搜索 / feeddd / RSSHub 微信路由 | 搜狗验证码墙（2026-08-25 复测：数据中心 IP 拿到的公众号搜索结果页为空壳）；feeddd 项目已停更；RSSHub 公共实例对通用抓取返回 403、微信路由长期不可用——均不满足「稳定公开聚合入口」 |
+| profile_ext / homepage（微信官方页） | `mp/profile_ext?action=home` 无会话返回「请在微信客户端打开」；`mp/homepage?f=json` 仅对开通页面模板的号有效（抽样 `ret:5`）——与无账号定位冲突 |
+| freewechat.com（自由微信存档） | `profile/<biz>` 可按 biz 直出存档页，但 `?rss` 同为 content:encoded 全文（抽样 3MB）、站内搜索 403；可达性与合规敏感度不适合内置 |
 
 验证方式：新增源均用 `parseSourcePayload`（新 kind 解析器）对线上响应做端到端冒烟
 （uisdc 两页 40+40 条、重叠 1 条、日期/封面齐全；4 个镜像与 woshipm 全部条目带真实

--- a/docs/news-sources.md
+++ b/docs/news-sources.md
@@ -77,7 +77,7 @@
 | `lastweek-ai` `import-ai` `ahead-of-ai` `lil-log` `simonw` `interconnects` | feed | 周报与作者博；Substack/静态站均正常 |
 | `arena` | arena | 无官方 RSS；解析官网 Blog 列表页（Sanity 嵌入数据） |
 | `anthropic` | anthropic | 无官方 RSS；解析 `/news` 列表页（Sanity）；URL 带尾斜杠会 308，代理 rewrite 不跟随，必须无尾斜杠 |
-| `xixiaoyao` `paperweekly` `42zhangjing` | wechat2rss | 公众号镜像（第三方 wechat2rss 公共实例），feed 自带全文；探测与风险见 §4 |
+| `xixiaoyao` `paperweekly` `42zhangjing` | wechat | 公众号解析器；列表过渡数据源为 wechat2rss 镜像 feed（自带全文），缺全文时直连 mp.weixin.qq.com 文章页抽正文；探测与风险见 §4 |
 | `uisdc-aigc` | uisdc | 优设 AIGC 标签页，无 RSS；解析归档 HTML + `/page/N` 翻页，正文 Readability；见 §4 |
 | `woshipm-ai` | feed | 人人都是产品经理 AI 分类 WP feed，全文；见 §4 |
 
@@ -148,21 +148,40 @@ WebView 观察页面的网络、DOM、MSE 与 DRM 信号；接口或观察失败
 **第三方镜像 + 自定义解析**路径接入，并补充设计/产品社区频道（体验解读、工具评测、
 教程深读），面向「无法亲手玩模型」的读者。
 
-### 4.1 公众号镜像（kind `wechat2rss`）
+### 4.1 公众号解析器（kind `wechat`；2026-08-26 由 `wechat2rss` kind 升级）
 
-抓取路径：wechat2rss 公共实例（`https://wechat2rss.xlab.app`，第三方维护，收录约
-395 个号）。实例基址集中在 `registry.ts` 的 `WECHAT2RSS_BASE`，失效或换址只改一处。
+`wechat` 是一等公民 kind（公众号解析器），旧 kind 名 `wechat2rss` 由
+`normalizeSourceKind` 归一兼容（旧备份 / 旧自建源无需迁移）。解析器按响应载荷分流，
+支持两类列表入口：
 
-feed 结构（2026-08-25 实测）：标准 RSS 2.0，`content:encoded` 自带**完整正文**，
-图片经镜像 `img-proxy` 中转（绕开 mmbiz.qpic.cn Referer 防盗链）。因此**正文主路径 =
-feed 自带全文**（`isSubstantialHtml` 通过，站内直接渲染）；已知模板噪声由
-`cleanWechat2rssContentHtml` 剥离：头部「原创 作者 日期 地点」meta 行、尾部
-「跳转微信打开」link-proxy 链接、隐藏的 `<mp-style-type>`。
+- **镜像 feed（内置号的过渡列表数据源）**：wechat2rss 公共实例
+  （`https://wechat2rss.xlab.app`，第三方维护，收录约 395 个号）。实例基址集中在
+  `registry.ts` 的 `WECHAT2RSS_BASE`，失效或换址只改一处。微信不提供无登录的公众号
+  全量文章流（profile_ext 需要会话、搜狗有验证码墙，见 §4.3），故内置三号仍以镜像
+  feed 取列表，但解析与正文不再依赖镜像模板。
+- **公开合集直连（appmsgalbum）**：`mp.weixin.qq.com/mp/appmsgalbum?action=getalbum
+  &__biz=…&album_id=…&f=json`，无登录可访问（2026-08-26 实测数据中心 IP 亦可），
+  返回 `getalbum_resp.article_list`（标题 / 原文链接 / 秒级 `create_time` /
+  `cover_img_1_1` 封面）。自定义源粘贴合集分享链接时由 `isWechatAlbumUrl` 识别、
+  `normalizeWechatAlbumUrl` 归一成 JSON 列表入口（`addCustomSource` 自动定 kind）。
+  合集只含作者手工归档的文章，不等于全量文章流。
 
-回源兜底：`originUrl` 为 `mp.weixin.qq.com` 原文页。实测数据中心 IP 直抓会 302 到
-`wappoc_appmsgcaptcha` 验证码页（正文近乎空白，Readability 判「过短」后走摘要 +
-打开原文的软降级）；移动端住宅网络通常可正常返回文章 HTML。故列表缓存过期、
-`bodyCache` 又被逐出的旧文在部分网络下只能读镜像摘要。
+镜像 feed 结构（2026-08-25 实测）：标准 RSS 2.0，`content:encoded` 自带**完整正文**，
+图片经镜像 `img-proxy` 中转（绕开 mmbiz.qpic.cn Referer 防盗链）。feed 自带全文时
+**正文主路径 = feed 全文**（`isSubstantialHtml` 通过，站内直接渲染）；已知噪声由
+`cleanWechatArticleHtml` 剥离：头部「原创 作者 日期 地点」meta 行、尾部
+「跳转微信打开」link-proxy 链接、隐藏的 `<mp-style-type>`（微信编辑器产物，
+原文页里同样存在）。
+
+直连正文路径（feed 缺全文 / 合集条目 / 旧文缓存被逐出时）：`resolveBody` 抓
+`mp.weixin.qq.com` 文章页，由 `extractWechatBodyHtml` 取 `#js_content`
+（.rich_media_content）——容器带 `visibility: hidden` 内联样式、图片全部 `data-src`
+懒加载（由 `normalizeContentImages` 统一提升并加 `referrerpolicy="no-referrer"`），
+标题回填取 `og:title` / `#activity-name`。2026-08-26 实测：`/s/<slug>` 形态文章页
+对数据中心 IP 也返回完整 HTML；`/s?__biz=…` 参数形态在数据中心 IP 常返回
+`secitptpage/verify` 环境验证壳（无正文），已加入 `isBlockedPublisherHtml` 识别，
+命中后走换 UA → 翻译镜像 → 摘要 + 打开原文的既有软降级链。移动端住宅网络通常两种
+形态均可正常返回文章 HTML。
 
 首轮收录 4 个；二轮甄选（§5）移除差评，现存 3 个（均默认关闭，由「深读 / 社区」分类与
 「极客与 AI」预设承接）：

--- a/docs/superpowers/specs/2026-08-25-wechat-account-stream-research.md
+++ b/docs/superpowers/specs/2026-08-25-wechat-account-stream-research.md
@@ -1,0 +1,189 @@
+# 公众号「名称/ID → 信息流 + 文字详情」取流方案调研（2026-08-25）
+
+> 调研代理：Cloud Agent（数据中心 IP 环境）。Android 住宅网络的结论引用
+> PR #20（`cursor/wechat-mp-parser-e66e`）2026-08-26 真机冒烟记录。
+> 本文与 `docs/news-sources.md` §4 互为引用：§4 记「当前生效结论」，本文记
+> 完整比选过程与否决理由。
+
+## 0. 结论速览
+
+| 排序 | 路径 | 定位 |
+|---|---|---|
+| 1 | **wechat2rss 镜像 feed（仅取列表）+ 直连 mp 文章页取正文** | 内置号短期主路径；本轮已实施「列表剥离全文」最小改造 |
+| 2 | **公开合集 appmsgalbum JSON 直连** | 自定义源最优轻量列表（20 条 ≈ 14KB）；受作者手工归档限制，非全量流 |
+| 3 | 条件请求（ETag/304）与镜像单篇兜底 | follow-up，见 §6 |
+| ✗ | 搜狗微信、profile_ext、RSSHub 公共实例、freewechat、自建服务 | 均否决或仅作应急/文档备选，理由见 §3 |
+
+「按名称订阅」没有免登录的全网入口（§5）；可达的近似是
+**镜像目录内名称检索**（wechat2rss `/list/all`，约 395 号）与**用户粘贴合集/文章
+分享链接**（biz 提取，已在 kind `wechat` 实现合集链接识别）。
+
+## 1. 需求与硬约束
+
+- 输入是「公众号名称 / 微信号 / biz / 合集 ID / feed hash」中任意一种，输出：
+  ① 轻量信息流（标题、链接、时间、封面，**不含全文**）；② 站内可读的文字正文。
+- 硬约束：Backendless（无自建 API）、站内全文、本地持久化、Android WebView
+  客户端直连（Web 生产走 Cloudflare 边缘代理 = 数据中心 IP）。
+- 本轮新增强制约束：**信息流与正文分离**——列表拉取不得携带全文；正文点击/预取
+  时按需 `resolveBody`，复用 `bodyCache` 预算与 pin。
+
+## 2. 候选路径打表
+
+打分维度：A 账号定位方式 · B 列表轻量性 · C 正文二次获取 · D 稳定性/风控 ·
+E 硬约束契合 · F 「按名称订阅」支持。
+
+### 2.1 wechat2rss 第三方镜像（现内置路径）
+
+- **A**：feed hash（不可由名称/biz 本地推导，sha1 候选均不匹配；只能查实例目录
+  `/list/all`，77KB HTML，name → hash 锚点可解析，收录约 395 号）。
+- **B**：差——原始 feed 0.7MB～2.9MB（20 条），`content:encoded` 占 **98–99%**
+  体积；`<description>` 近乎为空（20 条合计 <1KB）。传输层缓解：支持 gzip
+  （2.9MB → 216KB wire）、支持 `ETag`/`If-None-Match` → 304（未变化时近零流量）；
+  **不支持 Range**（返回 200 全量）。剥离全文后剩余元数据仅 ~9–14KB。
+- **C**：条目链接为 `/s?__biz=…` 形态 → 数据中心 IP 会被 302 到验证页（见 §4），
+  住宅 IP（Android 真机）通常可直取 `#js_content`；镜像无单篇端点，但**重拉整个
+  feed（216KB gzip）可作单篇兜底**（follow-up）。
+- **D**：第三方公益实例（Cloudflare 前置），可能限流/下线/换址；img-proxy 与实例
+  同生命周期。
+- **E**：契合（纯客户端 GET；实例基址集中在 `WECHAT2RSS_BASE` 一处）。
+- **F**：目录内可按名称检索；目录外的号（归藏、Founder Park 等）无解。
+
+### 2.2 微信公开合集 appmsgalbum JSON
+
+- **A**：需要 `__biz` + `album_id`（来自用户粘贴的合集分享链接；仅名称无法定位）。
+- **B**：优——`f=json` 20 条 ≈ **13.8KB**，字段：`title` / `url` /
+  `create_time`（unix 秒）/ `cover_img_1_1`；正文不随列表下发。支持
+  `begin_msgid` + `begin_itemidx` 翻页（`continue_flag`），第二页 10 条 ≈ 6.5KB。
+- **C**：同 2.1 的直连 mp 文章页路径。
+- **D**：官方端点、无验证壳（2026-08-25 数据中心 IP 实测 ret=0 正常返回）；
+  但**内容为作者手工归档**，非全量流，且作者可下架/改名。
+- **E**：完全契合（已在 kind `wechat` 落地：`isWechatAlbumUrl` /
+  `normalizeWechatAlbumUrl` / `parseWechatAlbum`）。
+- **F**：不支持名称订阅；靠用户从微信分享合集链接。
+
+### 2.3 搜狗微信搜索
+
+- **A**：理论上名称 → 账号页；实测数据中心 IP 拿到的公众号搜索结果页是**空壳**
+  （标题正常、无任何结果条目与跳转链），历史行为还有验证码墙与一次性跳转链
+  （`/link?url=` 带时效签名）。
+- **B/C**：即便命中，结果页只给最近 10 篇且链接是临时签名形态，不可持久化为
+  `originUrl`。
+- **D**：差；反爬策略随时变化，客户端直连极不稳定。
+- **E/F**：名义上最接近「按名称订阅」，实际可用性不足以承载产品路径。**否决**
+  （维持 `docs/news-sources.md` §4.3 结论）。
+
+### 2.4 profile_ext / 历史消息页（微信官方 HTML/XHR）
+
+- 实测 `mp/profile_ext?action=home&__biz=…` 无会话时返回 2KB「请在微信客户端
+  打开」提示页；带会话的 XHR 翻页（`action=getmsg`）依赖微信客户端 Cookie
+  （key/uin/pass_ticket），无法在无账号前提下获得。**否决**：与「无账号」定位
+  冲突，且属于灰区接口，风控与封禁风险高。
+- 附注：`mp/homepage?__biz=…&f=json` 仅对开通「页面模板」的号有效（抽样返回
+  `ret:5`），不通用。
+
+### 2.5 RSSHub 微信路由
+
+- 公共实例 `rsshub.app` 已对通用抓取返回 403（“testing purposes only,
+  self-host for production”，2026-08-25 实测）；微信相关路由长期依赖第三方数据源
+  （feeddd 已停更等），可用性差。
+- 自托管 RSSHub 与 Backendless 冲突，不能作为内置路径；仅可在用户文档中作为
+  「自托管进阶玩法」提及（自定义源本就支持任意 RSS URL，无需改代码）。**否决
+  （内置）／可选（自托管文档）**。
+
+### 2.6 freewechat（自由微信，GreatFire 系存档）
+
+- `freewechat.com/profile/<biz>` 可按 biz 直出账号存档页（抽样 122KB，含
+  `/a/<biz>/<mid>` 文章链接），`?rss` 输出 RSS——但同样是 **content:encoded 全文
+  3MB**（与镜像同病）；站内搜索接口对本环境 403。
+- 定位是抗审查存档站，在目标用户群的网络环境下可达性波动大，且引用该站作为内置
+  数据源会给应用带来不必要的合规敏感度。**否决（内置）**；仅作单篇应急镜像的
+  已知选项记录（不写入代码）。
+
+### 2.7 自建 wechat2rss / 采集服务
+
+- 与 Backendless 硬约束直接冲突，**否决**。自托管者可把自建实例 URL 填进
+  自定义源（kind `wechat` 对镜像 feed 的解析与实例无关），无需为此改代码。
+
+## 3. 否决汇总
+
+| 路径 | 否决理由（一句话） |
+|---|---|
+| 搜狗微信 | 数据中心 IP 空壳/验证码墙、结果链接带时效签名，不可持久化 |
+| profile_ext / getmsg | 需微信客户端会话，与无账号定位冲突，风控高 |
+| RSSHub 公共实例 | 403 拒绝通用抓取；微信路由上游长期不可用 |
+| freewechat | 全文 RSS 同样超重；可达性与合规敏感度不适合内置 |
+| 自建服务 | 违反 Backendless |
+
+## 4. 实测记录（2026-08-25，云端数据中心 IP）
+
+抽样命令均为普通 HTTP GET（Android Chrome UA），不含任何登录态。
+
+| 探测点 | 结果 |
+|---|---|
+| `wechat2rss.xlab.app/feed/a1cd…a34d.xml`（夕小瑶） | 200，700,875 B，20 条，`content:encoded` 占 98%，`<description>` 合计 187 B |
+| `…/feed/3be8…a563.xml`（PaperWeekly） | 200，2,900,958 B，20 条，全文占 99%；gzip 后 wire 215,742 B |
+| 同 URL + `If-None-Match`（原样 ETag） | **304**，0 B——镜像支持条件请求 |
+| 同 URL + `Range: bytes=0-4095` | 200 全量——不支持 Range |
+| `wechat2rss.xlab.app/list/all` | 200，77KB HTML，锚点含「名称 → /feed/<hash>.xml」全量映射 |
+| `mp/appmsgalbum…f=json`（看理想·李想主义合集） | 200，13,820 B / 20 条，`ret=0`，字段齐（title/url/create_time/cover_img_1_1），`continue_flag=1` |
+| 同端点 + `begin_msgid`/`begin_itemidx` | 200，6,563 B / 10 条——翻页可用 |
+| mp 文章页 `/s?__biz=…`（feed 条目链接形态） | 302 → `mp/wappoc_appmsgcaptcha` 验证页（无正文）；与 PR #20 记录一致 |
+| mp 文章页 `/s/<slug>` | 200，3.1MB HTML，`#js_content` 与 `og:title` 在，无验证壳——数据中心 IP 亦可读 |
+| `weixin.sogou.com/weixin?type=1&query=…` | 200 但结果区为空壳（无条目、无跳转链） |
+| `mp/profile_ext?action=home&__biz=…` | 200，2KB「请在微信客户端打开」 |
+| `mp/homepage?__biz=…&f=json` | `{"base_resp":{"ret":5}}`——仅开通页面模板的号可用 |
+| `rsshub.app/wechat/…` | 403（公共实例限制通用抓取） |
+| `freewechat.com/profile/<biz>` | 200，122KB 存档页；`?rss` 3,054,680 B 全文 RSS；`/search` 403 |
+
+风控相关只记录现象（验证页/空壳/403），不展开绕过手段。
+
+## 5. 「名称/ID → 流」缺口说明
+
+微信不提供免登录的「名称 → biz → 文章流」公开链路；搜狗是唯一名义入口且已实测
+不可用。产品上「按名称订阅」只能做到：
+
+1. **镜像目录内检索**（follow-up，可选）：拉 `/list/all`（77KB，可日缓存），
+   客户端模糊匹配名称 → feed hash → 即刻订阅。覆盖约 395 号，命中率有限但零后端。
+2. **粘贴合集链接**（已实现）：微信内「合集 → 分享」链接粘贴进自定义源，
+   `addCustomSource` 自动识别 kind `wechat` 并归一为 JSON 列表入口。
+3. **粘贴文章链接**（follow-up，可选）：文章页内嵌 `appmsgalbuminfo` 变量，若该文
+   属于合集可发现 `album_id` 反推列表入口；不属于任何合集的号仍无解。
+4. feed hash 无法本地推导（对名称/微信号/biz 的 sha1/md5 均不匹配目录值），
+   必须查目录，不要试图在客户端「算」出 hash。
+
+## 6. 强制约束落地：信息流与正文分离
+
+现状核对（kind `wechat`，PR #20 分支）：
+
+- 列表**持久化**层已安全：`storage.ts` 的 `compactCachedArticle` 写缓存前一律剥离
+  `contentHtml`（读取旧缓存时也原位压缩）。
+- 但**解析层**仍把 `content:encoded` 全文放进内存态 `Article` 并作为正文主路径
+  （`resolveArticleBody` 的 `bodySource: 'feed'` 短路），单源会话内存滞留最高
+  ~2.9MB，与「列表只拿元数据」相悖。
+
+本轮最小改造（随本 PR 实施）：
+
+- `parseWechatMirrorFeed` 在派生摘要（220 字）与封面（首图，img-proxy URL）后
+  **丢弃 `contentHtml`**；列表条目只剩元数据。
+- 正文统一走既有按需路径：`resolveBody` 直连 mp 文章页 →
+  `extractWechatBodyHtml`（`#js_content`）→ 验证壳时软降级；读过的文章由
+  `bodyCache`（约 3MB 预算 + 稍后读 pin）承接，重开不再请求。
+- 合集列表（`parseWechatAlbum`）本就不带正文，无需改动。
+
+代价与缓解：
+
+- 打开文章从「零等待（feed 全文）」变为「按需网络」——与网易/知乎等多数内置源
+  行为一致；稍后读预取（`App.tsx` 的 `prefetchBody`）与 bodyCache 缓解重复请求。
+- Web 生产（边缘代理 = 数据中心 IP）对 `/s?__biz=` 形态命中验证壳的概率高，剥离
+  后该环境的公众号正文可达性下降，走摘要 + 打开原文兜底；Android（产品主体）
+  住宅网络不受影响。
+
+Follow-up（按优先级，不在本 PR 内）：
+
+1. **feed 刷新条件请求**：`lib/http.ts` 记录 `ETag` 并带 `If-None-Match` 重访，
+   304 时复用列表缓存。镜像已支持；对所有 RSS 源普适（thezvi 2MB 等同样受益）。
+   需评估 CapacitorHttp 与边缘代理的透传。
+2. **镜像单篇兜底**：直连 mp 命中验证壳时，重拉该源镜像 feed（gzip ~216KB）在
+   内存中摘出目标条目的 `content:encoded` 作正文（不落列表缓存）。主要救 Web
+   生产环境。
+3. **目录内名称检索**（§5.1）与**文章链接反推合集**（§5.3）。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "1.6.5",
+      "version": "1.6.6",
       "dependencies": {
         "@capacitor-community/media": "^9.1.0",
         "@capacitor/android": "8.4.2",
@@ -1058,9 +1058,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1078,9 +1075,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1098,9 +1092,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1118,9 +1109,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1138,9 +1126,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1158,9 +1143,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1178,9 +1160,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1198,9 +1177,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1376,9 +1352,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1394,9 +1367,6 @@
       "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1414,9 +1384,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1432,9 +1399,6 @@
       "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1452,9 +1416,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1470,9 +1431,6 @@
       "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1826,9 +1784,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1848,9 +1803,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -1872,9 +1824,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1894,9 +1843,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -2061,9 +2007,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2079,9 +2022,6 @@
       "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2099,9 +2039,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2117,9 +2054,6 @@
       "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4976,9 +4910,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4998,9 +4929,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5022,9 +4950,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5044,9 +4969,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "1.6.6",
+  "version": "1.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "1.6.6",
+      "version": "1.6.5",
       "dependencies": {
         "@capacitor-community/media": "^9.1.0",
         "@capacitor/android": "8.4.2",
@@ -1058,6 +1058,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1075,6 +1078,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1092,6 +1098,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1109,6 +1118,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,6 +1138,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1143,6 +1158,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1160,6 +1178,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1177,6 +1198,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1352,6 +1376,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1367,6 +1394,9 @@
       "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1384,6 +1414,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1399,6 +1432,9 @@
       "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1416,6 +1452,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1431,6 +1470,9 @@
       "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1784,6 +1826,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1803,6 +1848,9 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -1824,6 +1872,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1843,6 +1894,9 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -2007,6 +2061,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2022,6 +2079,9 @@
       "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2039,6 +2099,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2054,6 +2117,9 @@
       "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4910,6 +4976,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4929,6 +4998,9 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -4950,6 +5022,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4969,6 +5044,9 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/scripts/community-wechat-sources.test.ts
+++ b/scripts/community-wechat-sources.test.ts
@@ -3,7 +3,7 @@
  * 1. 注册表与分类覆盖 / 互斥自检（含 wechat2rss → wechat 兼容别名）
  * 2. 优设 tag 列表页解析器（卡片抽取、导航过滤、日期与配图）
  * 3. 优设 /page/N 翻页映射与分页策略
- * 4. 公众号镜像 feed 噪声清洗（meta 行 / 跳转微信打开 / mp-style-type）与全文判断
+ * 4. 公众号镜像 feed 噪声清洗（meta 行 / 跳转微信打开 / mp-style-type）与列表剥离全文
  * 5. 优设详情正文（group 图集 / 长文避开 uisdc-none + 阅读文章卡片）
  * 6. 公众号公开合集 JSON 列表解析（appmsgalbum）与合集链接归一
  * 7. 公众号文章页正文抽取（js_content / data-src / 验证壳拒收）
@@ -196,11 +196,11 @@ for (const id of WECHAT_ACCOUNT_IDS) {
 
 console.log('✓ uisdc /page/N offset paging & wechat client-catalog verified')
 
-// —— 4. 公众号镜像 feed 正文清洗与全文判断 ——
+// —— 4. 公众号镜像 feed 正文清洗与列表剥离全文（信息流与正文分离）——
 const body = Array.from(
   { length: 20 },
   (_, i) =>
-    `<p>第 ${i + 1} 段：这是一段足够长的正文内容，用来验证公众号镜像 feed 自带全文可以直接作为站内正文渲染，而不需要回源抓取微信页面；镜像图片经 img-proxy 中转，正文文字则完整保留在 content:encoded 里。</p>`,
+    `<p>第 ${i + 1} 段：这是一段足够长的正文内容，用来验证公众号镜像 feed 的 content:encoded 全文只被拿来派生摘要与封面，列表条目本身不携带全文；正文改由 resolveBody 按需直连微信文章页抽取。</p>`,
 ).join('')
 
 const wechatFixture = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
@@ -227,25 +227,29 @@ assert.equal(wechatArticles.length, 1)
 const [wechatArticle] = wechatArticles
 assert.equal(wechatArticle.title, '黄仁勋被曝当上 AI 圈“红娘”，算力大战突然换了玩法')
 assert.equal(wechatArticle.hasRealDate, true)
-assert.ok(wechatArticle.contentHtml, 'contentHtml must be kept from content:encoded')
-assert.ok(!wechatArticle.contentHtml!.includes('跳转微信打开'), 'mirror tail link must be stripped')
-assert.ok(!wechatArticle.contentHtml!.includes('mp-style-type'), 'mp-style-type must be stripped')
-assert.ok(
-  !/原创\s*阿雅/.test(wechatArticle.contentHtml!),
-  'leading author/date meta line must be stripped',
+// 信息流与正文分离：content:encoded（占 feed 体积 98–99%）不得进列表条目，
+// 正文由 resolveBody 按需直连文章页；列表持久化层的剥离另有 compactCachedArticle 兜底
+assert.equal(
+  wechatArticle.contentHtml,
+  undefined,
+  'mirror fulltext must be dropped from list items (list/body separation)',
 )
-assert.ok(wechatArticle.contentHtml!.includes('img-proxy'), 'image via mirror proxy must survive')
 assert.ok(wechatArticle.summary.startsWith('第 1 段'), 'summary must start from real body text')
 assert.ok(
-  isSubstantialHtml(wechatArticle.contentHtml),
-  'mirror full text must pass the substantial check (in-app reading without refetch)',
+  !/原创\s*阿雅/.test(wechatArticle.summary),
+  'leading author/date meta line must not leak into summary',
+)
+assert.ok(wechatArticle.summary.length <= 220, 'summary must stay a short field')
+assert.ok(
+  wechatArticle.image?.includes('/img-proxy/'),
+  'cover must be derived from the first body image before dropping fulltext',
 )
 
 // 清洗器不得误伤：没有 meta 行的正文首段必须原样保留
 const plain = '<p>这是一篇没有镜像模板噪声的正文首段。</p><p>第二段。</p>'
 assert.equal(cleanWechatArticleHtml(plain), plain)
 
-console.log('✓ wechat mirror feed boilerplate cleanup & fulltext check verified')
+console.log('✓ wechat mirror feed boilerplate cleanup & list/body separation verified')
 
 // —— 5. 优设详情正文：避开 Readability 的 uisdc-none / 图集兄弟节点坑 ——
 const groupDetailFixture = `

--- a/scripts/community-wechat-sources.test.ts
+++ b/scripts/community-wechat-sources.test.ts
@@ -1,31 +1,44 @@
 /**
- * 公众号镜像（wechat2rss）与社区频道（优设 AIGC / 人人PM）专项测试：
- * 1. 注册表与分类覆盖 / 互斥自检
+ * 公众号解析器（kind `wechat`）与社区频道（优设 AIGC / 人人PM）专项测试：
+ * 1. 注册表与分类覆盖 / 互斥自检（含 wechat2rss → wechat 兼容别名）
  * 2. 优设 tag 列表页解析器（卡片抽取、导航过滤、日期与配图）
  * 3. 优设 /page/N 翻页映射与分页策略
- * 4. wechat2rss 正文噪声清洗（meta 行 / 跳转微信打开 / mp-style-type）与全文判断
+ * 4. 公众号镜像 feed 噪声清洗（meta 行 / 跳转微信打开 / mp-style-type）与全文判断
  * 5. 优设详情正文（group 图集 / 长文避开 uisdc-none + 阅读文章卡片）
+ * 6. 公众号公开合集 JSON 列表解析（appmsgalbum）与合集链接归一
+ * 7. 公众号文章页正文抽取（js_content / data-src / 验证壳拒收）
  *
  * 用法：npx tsx scripts/community-wechat-sources.test.ts
  */
 import assert from 'node:assert/strict'
 
-import { cleanWechat2rssContentHtml, parseSourcePayload } from '../src/lib/parseFeed'
-import { extractUisdcBodyHtml, isSubstantialHtml } from '../src/lib/resolveBody'
+import { cleanWechatArticleHtml, parseSourcePayload } from '../src/lib/parseFeed'
+import {
+  extractUisdcBodyHtml,
+  extractWechatArticleTitle,
+  extractWechatBodyHtml,
+  isBlockedPublisherHtml,
+  isSubstantialHtml,
+  isWechatArticleUrl,
+} from '../src/lib/resolveBody'
 import { sanitizeArticleHtml } from '../src/lib/sanitize'
 import { CATEGORIES, uncoveredSourceIds } from '../src/sources/categories'
+import { DEFAULT_PREFERENCES, addCustomSource } from '../src/sources/preferences'
 import { duplicateSourcesAcrossCategories } from '../src/sources/presets'
 import {
   findSource,
+  isWechatAlbumUrl,
   maxOffsetPages,
+  normalizeSourceKind,
+  normalizeWechatAlbumUrl,
   offsetPageRequest,
   pagingStrategyOf,
   WECHAT2RSS_BASE,
 } from '../src/sources/registry'
 
 // —— 1. 注册表与分类检查 ——
-// 二轮甄选后仅保留 3 个真·深度公众号镜像；差评（chaping）已移除，见 docs/news-sources.md §5
-const WECHAT_MIRROR_IDS = ['xixiaoyao', 'paperweekly', '42zhangjing']
+// 二轮甄选后仅保留 3 个真·深度公众号；差评（chaping）已移除，见 docs/news-sources.md §5
+const WECHAT_ACCOUNT_IDS = ['xixiaoyao', 'paperweekly', '42zhangjing']
 const COMMUNITY_IDS = ['uisdc-aigc', 'woshipm-ai']
 
 assert.equal(
@@ -34,23 +47,27 @@ assert.equal(
   'chaping was removed in the curation round and must stay unregistered',
 )
 
-for (const id of [...WECHAT_MIRROR_IDS, ...COMMUNITY_IDS]) {
+for (const id of [...WECHAT_ACCOUNT_IDS, ...COMMUNITY_IDS]) {
   const src = findSource(id)
   assert.ok(src, `Source ${id} must be registered in SOURCES`)
   assert.ok(src.name && src.label, `Source ${id} must have name and label`)
   assert.ok(src.url.startsWith('https://'), `Source ${id} must use https`)
 }
 
-for (const id of WECHAT_MIRROR_IDS) {
+for (const id of WECHAT_ACCOUNT_IDS) {
   const src = findSource(id)!
-  assert.equal(src.kind, 'wechat2rss', `${id} must use the wechat2rss kind`)
+  assert.equal(src.kind, 'wechat', `${id} must use the wechat kind (公众号解析器)`)
   assert.ok(
     src.url.startsWith(`${WECHAT2RSS_BASE}/feed/`),
-    `${id} feed URL must come from WECHAT2RSS_BASE`,
+    `${id} transitional list URL must come from WECHAT2RSS_BASE`,
   )
   // 第三方镜像默认关闭，由分类 / 预设按需启用
   assert.equal(src.enabled, false, `${id} must default to disabled`)
 }
+
+// 旧自建源 / 备份里的 wechat2rss kind 必须归一到公众号解析器
+assert.equal(normalizeSourceKind('wechat2rss'), 'wechat')
+assert.equal(normalizeSourceKind('wechat'), 'wechat')
 
 assert.equal(findSource('uisdc-aigc')!.kind, 'uisdc')
 assert.equal(findSource('woshipm-ai')!.kind, 'feed')
@@ -172,14 +189,14 @@ assert.equal(offsetPageRequest(uisdcSource, 0).url, 'https://www.uisdc.com/tag/a
 assert.equal(offsetPageRequest(uisdcSource, 1).url, 'https://www.uisdc.com/tag/aigc/page/2')
 assert.equal(offsetPageRequest(uisdcSource, 4).url, 'https://www.uisdc.com/tag/aigc/page/5')
 
-// 公众号镜像是纯 RSS：一次目录 + 客户端窗口
-for (const id of WECHAT_MIRROR_IDS) {
+// 公众号列表是一次目录 + 客户端窗口
+for (const id of WECHAT_ACCOUNT_IDS) {
   assert.equal(pagingStrategyOf(findSource(id)!), 'client-catalog', id)
 }
 
-console.log('✓ uisdc /page/N offset paging & wechat2rss client-catalog verified')
+console.log('✓ uisdc /page/N offset paging & wechat client-catalog verified')
 
-// —— 4. wechat2rss 正文清洗与全文判断 ——
+// —— 4. 公众号镜像 feed 正文清洗与全文判断 ——
 const body = Array.from(
   { length: 20 },
   (_, i) =>
@@ -226,9 +243,9 @@ assert.ok(
 
 // 清洗器不得误伤：没有 meta 行的正文首段必须原样保留
 const plain = '<p>这是一篇没有镜像模板噪声的正文首段。</p><p>第二段。</p>'
-assert.equal(cleanWechat2rssContentHtml(plain), plain)
+assert.equal(cleanWechatArticleHtml(plain), plain)
 
-console.log('✓ wechat2rss boilerplate cleanup & fulltext check verified')
+console.log('✓ wechat mirror feed boilerplate cleanup & fulltext check verified')
 
 // —— 5. 优设详情正文：避开 Readability 的 uisdc-none / 图集兄弟节点坑 ——
 const groupDetailFixture = `
@@ -280,4 +297,155 @@ assert.equal((postBody.match(/<img\b/gi) || []).length, 3, 'post body keeps hero
 
 console.log('✓ uisdc detail body extractor keeps group gallery & post images')
 
-console.log('\nAll community & wechat mirror source tests passed!')
+// —— 6. 公众号公开合集 JSON 列表（appmsgalbum 直连入口）——
+const albumShareUrl =
+  'https://mp.weixin.qq.com/mp/appmsgalbum?__biz=MzA3MDM3NjE5NQ==&action=getalbum&album_id=1375870284640911361&scene=173&from_msgid=2247487974&from_itemidx=1&count=3&nolastread=1#wechat_redirect'
+assert.equal(isWechatAlbumUrl(albumShareUrl), true)
+assert.equal(isWechatAlbumUrl('https://mp.weixin.qq.com/s/AbCdEf'), false)
+assert.equal(isWechatAlbumUrl('https://example.com/mp/appmsgalbum?__biz=x&album_id=1'), false)
+
+const albumListUrl = normalizeWechatAlbumUrl(albumShareUrl)
+{
+  const parsed = new URL(albumListUrl)
+  assert.equal(parsed.hostname, 'mp.weixin.qq.com')
+  assert.equal(parsed.pathname, '/mp/appmsgalbum')
+  assert.equal(parsed.searchParams.get('f'), 'json', 'list URL must request JSON payload')
+  assert.equal(parsed.searchParams.get('__biz'), 'MzA3MDM3NjE5NQ==')
+  assert.equal(parsed.searchParams.get('album_id'), '1375870284640911361')
+  assert.ok(!albumListUrl.includes('#'), 'share fragment must be dropped')
+  assert.ok(!parsed.searchParams.get('scene'), 'share tracking params must be dropped')
+}
+// biz 简写参数（RSSHub 风格链接）同样可识别
+assert.equal(
+  isWechatAlbumUrl('https://mp.weixin.qq.com/mp/appmsgalbum?biz=MzA3MDM3NjE5NQ==&action=getalbum&album_id=1375870284640911361'),
+  true,
+)
+
+// 字段名与线上响应一致（2026-08-25 实测 getalbum_resp 形态）
+const albumFixture = JSON.stringify({
+  base_resp: { exportkey_token: '', ret: 0 },
+  getalbum_resp: {
+    article_list: [
+      {
+        cover_img_1_1: 'http://mmbiz.qpic.cn/mmbiz_jpg/cover-a/300',
+        create_time: '1755750000',
+        itemidx: '1',
+        msgid: '2650941860',
+        pos_num: '96',
+        title: '合集第一篇：深度长文',
+        url: 'http://mp.weixin.qq.com/s?__biz=MzA3MDM3NjE5NQ==&mid=2650941860&idx=1&sn=6c1da71ee86b9b5a46d053b6f76861d4#rd',
+      },
+      {
+        create_time: '1755660000',
+        title: '合集第二篇：无封面也可入列',
+        url: 'https://mp.weixin.qq.com/s?__biz=MzA3MDM3NjE5NQ==&mid=2650941800&idx=1&sn=abcdef0123456789abcdef0123456789',
+      },
+      { title: '缺链接的脏数据必须被跳过' },
+    ],
+    base_info: { article_count: '96' },
+    continue_flag: '1',
+  },
+})
+
+const albumSource = {
+  id: 'custom_wechatalbum',
+  name: '看理想 · 李厚辰专栏',
+  label: '看理想',
+  group: 'custom' as const,
+  kind: 'wechat' as const,
+  url: albumListUrl,
+  enabled: true,
+}
+const albumArticles = parseSourcePayload(albumSource, albumFixture)
+assert.equal(albumArticles.length, 2, 'dirty rows without link must be skipped')
+assert.equal(albumArticles[0].title, '合集第一篇：深度长文')
+assert.ok(
+  albumArticles[0].originUrl.startsWith('https://mp.weixin.qq.com/s?__biz='),
+  'album item url must be https-upgraded',
+)
+assert.equal(albumArticles[0].hasRealDate, true, 'create_time (unix seconds) must be parsed')
+assert.equal(albumArticles[0].publishedAt, 1755750000 * 1000)
+assert.equal(
+  albumArticles[0].image,
+  'https://mmbiz.qpic.cn/mmbiz_jpg/cover-a/300',
+  'cover_img_1_1 must be https-upgraded as cover',
+)
+assert.equal(albumArticles[0].contentHtml, undefined, 'album list carries no body; reader resolves it')
+assert.equal(albumArticles[1].image, undefined)
+
+// ret 非 0（参数错误 / 合集不可见）与非 JSON 均安全返回空列表
+assert.deepEqual(
+  parseSourcePayload(albumSource, JSON.stringify({ base_resp: { ret: 10004 } })),
+  [],
+)
+assert.deepEqual(parseSourcePayload(albumSource, '{ not json'), [])
+
+// 自定义源粘贴合集分享链接：kind 识别为 wechat，URL 归一为 JSON 列表入口
+{
+  const { nextPrefs, newSourceId } = addCustomSource(DEFAULT_PREFERENCES, {
+    name: '看理想 · 李厚辰专栏',
+    url: albumShareUrl,
+  })
+  const added = nextPrefs.customSources?.find((s) => s.id === newSourceId)
+  assert.ok(added, 'custom album source must be added')
+  assert.equal(added.kind, 'wechat')
+  assert.equal(added.url, albumListUrl)
+}
+
+console.log('✓ wechat album JSON listing & custom album source detection verified')
+
+// —— 7. 公众号文章页正文抽取 ——
+assert.equal(isWechatArticleUrl('https://mp.weixin.qq.com/s/d8fJvLQ4o7wjr_4YBXGgqQ'), true)
+assert.equal(
+  isWechatArticleUrl('https://mp.weixin.qq.com/s?__biz=MzIwNzc2NTk0NQ==&mid=1&idx=1&sn=x'),
+  true,
+)
+assert.equal(isWechatArticleUrl('https://www.uisdc.com/seedance-2-5-5'), false)
+
+// 文章页骨架与线上一致：og:title、activity-name 标题、js_content 带 visibility:hidden，
+// 图片全部 data-src 懒加载（mmbiz CDN），文末夹 mp-style-type 排版标记
+const wechatParagraphs = Array.from(
+  { length: 12 },
+  (_, i) =>
+    `<p style="line-height: 1.75em;">第 ${i + 1} 段：直连 mp.weixin.qq.com 文章页抽出的正文内容，用于验证公众号解析器无需镜像也能拿到站内全文。</p>`,
+).join('')
+const wechatPageFixture = `<!DOCTYPE html><html><head>
+<meta property="og:title" content="直连正文抽取样张" />
+</head><body>
+<div class="rich_media">
+  <h1 class="rich_media_title" id="activity-name"><span class="js_title_inner">直连正文抽取样张</span></h1>
+  <div class="rich_media_content js_underline_content defaultNoSetting" id="js_content" style="visibility: hidden; opacity: 0; ">
+    <p><img class="rich_pages wxw-img" data-ratio="0.5" data-src="https://mmbiz.qpic.cn/sz_mmbiz_jpg/hero/640?wx_fmt=jpeg" data-w="1080" width="100%"></p>
+    ${wechatParagraphs}
+    <p style="display: none;"><mp-style-type data-value="3"></mp-style-type></p>
+  </div>
+</div>
+<div id="js_pc_qr_code">打开微信扫一扫</div>
+</body></html>`
+
+const wechatBody = extractWechatBodyHtml(wechatPageFixture)
+assert.ok(wechatBody, 'js_content body must be extracted')
+assert.ok(wechatBody.includes('第 1 段'), 'body text preserved')
+assert.ok(!wechatBody.includes('mp-style-type'), 'mp-style-type marker stripped')
+assert.ok(!wechatBody.includes('打开微信扫一扫'), 'page chrome outside js_content excluded')
+assert.ok(wechatBody.includes('data-src'), 'lazy images kept for normalizeContentImages to lift')
+assert.equal(extractWechatArticleTitle(wechatPageFixture), '直连正文抽取样张')
+assert.ok(isSubstantialHtml(wechatBody), 'direct-page body must pass the substantial check')
+
+// 验证壳（数据中心 IP 抓 /s?__biz=… 的常见响应）：没有 js_content，且必须判为拦截页
+const verifyShellFixture = `<!DOCTYPE html><html><head><title></title>
+<link rel="stylesheet" href="//res.wx.qq.com/mmbizwap/zh_CN/htmledition/style/page/secitptpage/verify802853.css" media="all">
+</head><body class="zh_CN"><div class="weui-msg"><div id="tips" class="top_tips warning"></div></div>
+<script>var PAGE_MID='mmbizwap:secitptpage/verify.html';</script></body></html>`
+assert.equal(extractWechatBodyHtml(verifyShellFixture), undefined, 'verify shell has no body')
+assert.equal(
+  isBlockedPublisherHtml(verifyShellFixture),
+  true,
+  'verify shell must be treated as blocked so the soft fallback engages',
+)
+// 正常文章页不得误判为拦截页
+assert.equal(isBlockedPublisherHtml(wechatPageFixture), false)
+
+console.log('✓ wechat article page extractor & verify-shell rejection verified')
+
+console.log('\nAll community & wechat source tests passed!')

--- a/scripts/community-wechat-sources.test.ts
+++ b/scripts/community-wechat-sources.test.ts
@@ -405,9 +405,9 @@ assert.equal(isWechatArticleUrl('https://www.uisdc.com/seedance-2-5-5'), false)
 // 文章页骨架与线上一致：og:title、activity-name 标题、js_content 带 visibility:hidden，
 // 图片全部 data-src 懒加载（mmbiz CDN），文末夹 mp-style-type 排版标记
 const wechatParagraphs = Array.from(
-  { length: 12 },
+  { length: 20 },
   (_, i) =>
-    `<p style="line-height: 1.75em;">第 ${i + 1} 段：直连 mp.weixin.qq.com 文章页抽出的正文内容，用于验证公众号解析器无需镜像也能拿到站内全文。</p>`,
+    `<p style="line-height: 1.75em;">第 ${i + 1} 段：直连 mp.weixin.qq.com 文章页抽出的正文内容，用于验证公众号解析器在镜像 feed 缺全文或合集条目没有正文时，仍然可以按站内全文路径完成阅读。</p>`,
 ).join('')
 const wechatPageFixture = `<!DOCTYPE html><html><head>
 <meta property="og:title" content="直连正文抽取样张" />

--- a/src/lib/parseFeed.ts
+++ b/src/lib/parseFeed.ts
@@ -1051,23 +1051,26 @@ export function cleanWechatArticleHtml(html: string): string {
 }
 
 /**
- * 公众号镜像 feed（wechat2rss，过渡列表数据源）：标准 RSS + content:encoded 全文，
- * 在通用 XML 解析后剥离镜像模板噪声并重算摘要。feed 自带全文时即正文主路径；
- * 缺全文时由 resolveBody 直连 mp.weixin.qq.com 文章页抽正文（extractWechatBodyHtml）。
+ * 公众号镜像 feed（wechat2rss，过渡列表数据源）：标准 RSS + content:encoded 全文
+ * （占 feed 体积 98–99%，实测 0.7–2.9MB/20 条）。信息流与正文分离：全文只用来派生
+ * 摘要与封面，不进列表条目；正文由 resolveBody 按需直连 mp.weixin.qq.com 文章页
+ * 抽取（extractWechatBodyHtml），bodyCache 承接已读缓存。
+ * 调研与取舍见 docs/superpowers/specs/2026-08-25-wechat-account-stream-research.md。
  */
 function parseWechatMirrorFeed(source: NewsSource, payload: string, fetchedAt: number): Article[] {
   return parseXmlFeed(source, payload, fetchedAt).map((article) => {
     if (!article.contentHtml) return article
     const cleaned = cleanWechatArticleHtml(article.contentHtml)
-    if (!cleaned.includes('<')) return article
+    // 清洗后没剩标签说明全文形态异常，仍从原始全文取摘要素材
+    const summarySource = cleaned.includes('<') ? cleaned : article.contentHtml
 
-    const summaryText = stripTags(cleaned)
+    const summaryText = stripTags(summarySource)
     const cleanedSummary = cleanSummaryText(summaryText, article.title)
     return {
       ...article,
-      contentHtml: cleaned,
+      contentHtml: undefined,
       summary: (cleanedSummary || summaryText).slice(0, 220),
-      image: article.image ?? firstImageIn(cleaned),
+      image: article.image ?? firstImageIn(summarySource),
     }
   })
 }

--- a/src/lib/parseFeed.ts
+++ b/src/lib/parseFeed.ts
@@ -1026,12 +1026,12 @@ function parseLatepost(source: NewsSource, payload: string, fetchedAt: number): 
 }
 
 /**
- * wechat2rss 镜像正文的已知噪声：
- * - 头部「原创 <作者> <YYYY-MM-DD HH:MM> <地点>」meta 行
- * - 尾部「跳转微信打开」link-proxy 链接
- * - 隐藏的 <mp-style-type> 排版标记
+ * 公众号正文的已知模板噪声（wechat2rss 镜像 feed 与 mp.weixin.qq.com 页面共用）：
+ * - 头部「原创 <作者> <YYYY-MM-DD HH:MM> <地点>」meta 行（镜像模板）
+ * - 尾部「跳转微信打开」link-proxy 链接（镜像模板）
+ * - 隐藏的 <mp-style-type> 排版标记（微信编辑器产物，原文页里也有）
  */
-export function cleanWechat2rssContentHtml(html: string): string {
+export function cleanWechatArticleHtml(html: string): string {
   let out = html
 
   const lead = out.match(/^\s*<p\b[^>]*>([\s\S]{0,600}?)<\/p>/)
@@ -1051,14 +1051,14 @@ export function cleanWechat2rssContentHtml(html: string): string {
 }
 
 /**
- * 公众号镜像（wechat2rss）：标准 RSS + content:encoded 全文，
- * 在通用 XML 解析后剥离镜像模板噪声并重算摘要。
- * 原文 mp.weixin.qq.com 对数据中心 IP 常回验证码页，故正文主路径是 feed 自带全文。
+ * 公众号镜像 feed（wechat2rss，过渡列表数据源）：标准 RSS + content:encoded 全文，
+ * 在通用 XML 解析后剥离镜像模板噪声并重算摘要。feed 自带全文时即正文主路径；
+ * 缺全文时由 resolveBody 直连 mp.weixin.qq.com 文章页抽正文（extractWechatBodyHtml）。
  */
-function parseWechat2rss(source: NewsSource, payload: string, fetchedAt: number): Article[] {
+function parseWechatMirrorFeed(source: NewsSource, payload: string, fetchedAt: number): Article[] {
   return parseXmlFeed(source, payload, fetchedAt).map((article) => {
     if (!article.contentHtml) return article
-    const cleaned = cleanWechat2rssContentHtml(article.contentHtml)
+    const cleaned = cleanWechatArticleHtml(article.contentHtml)
     if (!cleaned.includes('<')) return article
 
     const summaryText = stripTags(cleaned)
@@ -1070,6 +1070,75 @@ function parseWechat2rss(source: NewsSource, payload: string, fetchedAt: number)
       image: article.image ?? firstImageIn(cleaned),
     }
   })
+}
+
+/**
+ * 公众号公开合集（mp.weixin.qq.com/mp/appmsgalbum + f=json）：
+ * getalbum_resp.article_list 携带标题 / 原文链接 / 秒级时间戳 / 封面，正文不随列表下发，
+ * 打开条目时由 resolveBody 直连文章页抽取。ret 非 0（参数错误 / 合集不可见）返回空列表。
+ */
+function parseWechatAlbum(source: NewsSource, payload: string, fetchedAt: number): Article[] {
+  let data: Unknown
+  try {
+    data = JSON.parse(payload) as Unknown
+  } catch {
+    return []
+  }
+
+  const baseResp = asRecord(data.base_resp)
+  if (baseResp && Number(text(baseResp.ret) || '0') !== 0) return []
+
+  const resp = asRecord(data.getalbum_resp)
+  if (!resp) return []
+
+  const articles: Article[] = []
+  for (const raw of toArray(resp.article_list)) {
+    const node = asRecord(raw)
+    if (!node) continue
+    const title = text(node.title)
+    const link = text(node.url).replace(/^http:\/\//i, 'https://')
+    if (!title || !link.startsWith('https://')) continue
+
+    // create_time 为 unix 秒；缺失时留空走 fetchedAt
+    const createTime = Number(text(node.create_time))
+    const dateRaw =
+      Number.isFinite(createTime) && createTime > 0
+        ? new Date(createTime * 1000).toISOString()
+        : ''
+
+    const cover =
+      text(node.cover_img_1_1) ||
+      text(node.cover_img_url_1_1) ||
+      text(node.cover_img_url) ||
+      text(node.cover_url)
+
+    const article = buildArticle(
+      source,
+      {
+        title,
+        link,
+        html: '',
+        summaryText: '',
+        dateRaw,
+        image: cover.replace(/^http:\/\//i, 'https://') || undefined,
+      },
+      fetchedAt,
+    )
+    if (article) articles.push(article)
+  }
+
+  return articles
+}
+
+/**
+ * 公众号解析器（kind `wechat`）：按响应载荷分流——
+ * JSON 视为公开合集接口，其余按镜像 RSS 解析。
+ */
+function parseWechatSource(source: NewsSource, payload: string, fetchedAt: number): Article[] {
+  if (payload.trim().startsWith('{')) {
+    return parseWechatAlbum(source, payload, fetchedAt)
+  }
+  return parseWechatMirrorFeed(source, payload, fetchedAt)
 }
 
 /** 优设列表卡片里的站内功能页（非文章落地页） */
@@ -1567,7 +1636,7 @@ const PARSERS: Record<SourceKind, SourceParser> = {
   'eastmoney-news': parseEastmoneyNews,
   'wscn-live': parseWscnLive,
   paulgraham: parsePaulGraham,
-  wechat2rss: parseWechat2rss,
+  wechat: parseWechatSource,
   uisdc: parseUisdcTag,
   'web-catalog': parseWebCatalog,
 }

--- a/src/lib/resolveBody.ts
+++ b/src/lib/resolveBody.ts
@@ -31,6 +31,7 @@ import {
 } from './http'
 import { decodeGoogleNewsUrl, isGoogleNewsArticleUrl } from './googleNewsDecode'
 import { normalizeContentImages } from './normalizeImages'
+import { cleanWechatArticleHtml } from './parseFeed'
 import { buildPageLeadHtml, isSoftNotFoundHtml } from './pageLead'
 import { sanitizeArticleHtml } from './sanitize'
 import type { Article } from './types'
@@ -182,6 +183,10 @@ export function isBlockedPublisherHtml(html: string): boolean {
     /_0x[0-9a-f]{3,}\s*\(/i.test(head) &&
     /spinner|conic-gradient/i.test(head)
   ) {
+    return true
+  }
+  // 微信公众号环境验证壳：数据中心 IP 抓 /s?__biz=… 常返回 secitptpage/verify 空壳页
+  if (/secitptpage\/verify/i.test(head) || /环境异常[\s\S]{0,40}完成验证/.test(head)) {
     return true
   }
   return false
@@ -472,6 +477,48 @@ function isUisdcPageUrl(pageUrl: string): boolean {
   }
 }
 
+/** 公众号文章页（/s/<slug> 与 /s?__biz=… 两种形态同域） */
+export function isWechatArticleUrl(pageUrl: string): boolean {
+  try {
+    const parsed = new URL(pageUrl)
+    return parsed.hostname === 'mp.weixin.qq.com' && parsed.pathname.startsWith('/s')
+  } catch {
+    return false
+  }
+}
+
+/**
+ * 公众号文章页正文：内容固定在 `#js_content`（.rich_media_content），
+ * 容器带 `visibility: hidden` 内联样式、图片全部 data-src 懒加载——裸 Readability
+ * 会受隐藏样式与占位图干扰，直接取容器 innerHTML 再走统一图片提升更稳。
+ * 验证壳 / 已删除提示页没有 js_content，返回 undefined 交由通用链路兜底。
+ */
+export function extractWechatBodyHtml(pageHtml: string): string | undefined {
+  const { document } = parseHTML(pageHtml)
+  const root =
+    document.querySelector('#js_content') ||
+    document.querySelector('.rich_media_content')
+  if (!root) return undefined
+
+  const html = cleanWechatArticleHtml(
+    ((root as { innerHTML?: string }).innerHTML ?? '').trim(),
+  )
+  if (!html) return undefined
+  if (stripTags(html).length < 40 && !(html.match(/<img\b/gi) || []).length) {
+    return undefined
+  }
+  return html
+}
+
+/** 公众号文章标题（og:title 优先，回退 #activity-name）；分享短链无标题时回填阅读器 */
+export function extractWechatArticleTitle(pageHtml: string): string | undefined {
+  const og = pageHtml.match(/<meta[^>]+property="og:title"[^>]+content="([^"]*)"/i)?.[1]?.trim()
+  if (og) return og
+  const { document } = parseHTML(pageHtml)
+  const heading = document.querySelector('#activity-name')?.textContent?.trim()
+  return heading || undefined
+}
+
 async function extractWithReadability(
   pageHtml: string,
   pageUrl: string,
@@ -481,6 +528,17 @@ async function extractWithReadability(
     if (custom) {
       return {
         contentHtml: await absolutizeHtml(custom, pageUrl),
+        bodySource: 'readability',
+      }
+    }
+  }
+
+  if (isWechatArticleUrl(pageUrl)) {
+    const custom = extractWechatBodyHtml(pageHtml)
+    if (custom) {
+      return {
+        contentHtml: await absolutizeHtml(custom, pageUrl),
+        title: extractWechatArticleTitle(pageHtml),
         bodySource: 'readability',
       }
     }

--- a/src/sources/preferences.ts
+++ b/src/sources/preferences.ts
@@ -35,8 +35,10 @@ import { CATEGORIES, findCategory, PORTAL_VISIBLE_CATEGORY_IDS, type CategoryId,
 import {
   SOURCES,
   findSource,
+  isWechatAlbumUrl,
   makeCustomSourceId,
   normalizeSourceKind,
+  normalizeWechatAlbumUrl,
   type NewsSource,
   type SourceGroup,
 } from './registry'
@@ -705,7 +707,9 @@ export function addCustomSource(
   },
   targetCategoryId?: CategoryId,
 ): { nextPrefs: Preferences; newSourceId: string } {
-  const url = draft.url.trim()
+  // 公众号合集分享链接：归一成 JSON 列表入口并走公众号解析器
+  const wechatAlbum = !draft.kind && isWechatAlbumUrl(draft.url.trim())
+  const url = wechatAlbum ? normalizeWechatAlbumUrl(draft.url.trim()) : draft.url.trim()
   const name = draft.name.trim() || '自定义订阅'
   const label = draft.label?.trim() || name.slice(0, 4)
   const id = makeCustomSourceId(url)
@@ -719,7 +723,7 @@ export function addCustomSource(
     name,
     label,
     group,
-    kind: draft.kind ?? 'feed',
+    kind: draft.kind ?? (wechatAlbum ? 'wechat' : 'feed'),
     url,
     siteUrl: draft.siteUrl?.trim() || undefined,
     enabled: true,

--- a/src/sources/registry.ts
+++ b/src/sources/registry.ts
@@ -33,13 +33,15 @@ export type SourceKind =
   | 'eastmoney-news'
   | 'wscn-live'
   | 'paulgraham'
-  | 'wechat2rss'
+  | 'wechat'
   | 'uisdc'
   | 'web-catalog'
 
 /** 旧版自建源 kind 兼容 */
 export function normalizeSourceKind(kind: string | undefined): SourceKind {
   if (kind === 'web-video' || kind === 'web-catalog') return 'web-catalog'
+  // 公众号解析器升级前的旧 kind
+  if (kind === 'wechat2rss') return 'wechat'
   return (kind as SourceKind) || 'feed'
 }
 
@@ -115,12 +117,14 @@ export const OFFSET_MAX_PAGES: Partial<Record<SourceKind, number>> = {
 }
 
 /**
- * 公众号镜像入口（wechat2rss 公共实例，第三方维护）。
+ * 公众号解析器（kind `wechat`）的镜像列表入口（wechat2rss 公共实例，第三方维护）。
+ * 内置号目前仍以镜像 feed 为过渡列表数据源：微信不提供无登录的公众号全量文章流，
+ * 解析器另支持 mp.weixin.qq.com 公开合集 JSON 直连（见 normalizeWechatAlbumUrl）。
  * 该实例失效或换址时只需改这里；feed hash 与公众号的对应关系见 docs/news-sources.md §4。
  */
 export const WECHAT2RSS_BASE = 'https://wechat2rss.xlab.app'
 
-function wechatMirror(
+function wechatAccount(
   id: string,
   name: string,
   label: string,
@@ -132,10 +136,42 @@ function wechatMirror(
     name,
     label,
     group: options?.group ?? 'ai',
-    kind: 'wechat2rss',
+    kind: 'wechat',
     url: `${WECHAT2RSS_BASE}/feed/${feedHash}.xml`,
     enabled: options?.enabled ?? false,
   }
+}
+
+/** 公众号公开合集（appmsgalbum）分享链接；biz 参数有 __biz / biz 两种写法 */
+export function isWechatAlbumUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url.trim())
+    if (parsed.hostname !== 'mp.weixin.qq.com') return false
+    if (!parsed.pathname.startsWith('/mp/appmsgalbum')) return false
+    const biz = parsed.searchParams.get('__biz') || parsed.searchParams.get('biz')
+    return Boolean(biz && parsed.searchParams.get('album_id'))
+  } catch {
+    return false
+  }
+}
+
+/**
+ * 公众号合集链接归一成 JSON 列表入口：
+ * 去掉分享参数与 #wechat_redirect，补 f=json / count，保证列表请求拿到结构化数据。
+ */
+export function normalizeWechatAlbumUrl(url: string): string {
+  if (!isWechatAlbumUrl(url)) return url
+  const parsed = new URL(url.trim())
+  const biz = parsed.searchParams.get('__biz') || parsed.searchParams.get('biz') || ''
+  const albumId = parsed.searchParams.get('album_id') || ''
+  const search = new URLSearchParams({
+    action: 'getalbum',
+    __biz: biz,
+    album_id: albumId,
+    count: String(CATALOG_PAGE_SIZE),
+    f: 'json',
+  })
+  return `https://mp.weixin.qq.com/mp/appmsgalbum?${search.toString()}`
 }
 
 function neteaseList(tid: string): string {
@@ -532,14 +568,15 @@ export const SOURCES: NewsSource[] = [
   { id: 'latent-space', name: 'Latent Space', label: 'Latent', group: 'ai', kind: 'feed', url: 'https://www.latent.space/feed', enabled: false },
   // Zvi 周报综述极长，feed 近 2MB；默认关闭，按需启用
   { id: 'thezvi', name: "Don't Worry About the Vase", label: 'Zvi', group: 'ai', kind: 'feed', url: 'https://thezvi.substack.com/feed', enabled: false },
-  // —— 公众号镜像（wechat2rss 第三方公共实例；feed 自带全文即正文主路径）——
+  // —— 公众号（kind `wechat` 公众号解析器；列表过渡数据源为 wechat2rss 镜像 feed，
+  // feed 自带全文优先，缺全文时由解析器直连 mp.weixin.qq.com 文章页抽正文）——
   // 镜像属第三方维护、可能失效；默认关闭。二轮甄选只保留 3 个真·深度号，
   // 抽检数据、落选名单（差评等）与风险记录见 docs/news-sources.md §4 / §5
-  wechatMirror('xixiaoyao', '夕小瑶科技说', '夕小瑶', 'a1cd365aa14ed7d64cabfc8aa086da40ecaba34d'),
+  wechatAccount('xixiaoyao', '夕小瑶科技说', '夕小瑶', 'a1cd365aa14ed7d64cabfc8aa086da40ecaba34d'),
   // PaperWeekly feed 约 3MB（20 篇论文深读全文），刷新流量较大；不进默认预设
-  wechatMirror('paperweekly', 'PaperWeekly', 'PaperWeekly', '3be891c2f4e526629ab055a297cc2cd6c1f0a563'),
+  wechatAccount('paperweekly', 'PaperWeekly', 'PaperWeekly', '3be891c2f4e526629ab055a297cc2cd6c1f0a563'),
   // 42章经：AI/创投深度访谈，更新频率低（月 2–3 篇）
-  wechatMirror('42zhangjing', '42章经', '42章经', '31436fcc3bba8c2c2a9337a163afcb3b5a57a0a0'),
+  wechatAccount('42zhangjing', '42章经', '42章经', '31436fcc3bba8c2c2a9337a163afcb3b5a57a0a0'),
   // 优设无 RSS（/feed 返回首页 HTML、tag feed 与 WP REST 均 404）；解析 tag 列表页，/page/N 翻页
   {
     id: 'uisdc-aigc',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

调研「按公众号名称/ID 取信息流 + 文字详情」的可达路径，并落实**信息流与正文分离**（禁止列表一次吞数 MB 全文）。

### 调研结论（详见 spec）

1. **推荐（内置号短期）**：wechat2rss 镜像 feed **仅作列表** + 点击后直连 `mp.weixin.qq.com` 取正文。实测 feed 0.7–2.9MB 中 `content:encoded` 占 98–99%；剥离后列表 JSON ≈ 23KB。
2. **推荐（自定义源）**：公开合集 `appmsgalbum` JSON（轻量，PR #20 已落地）。
3. **否决**：搜狗微信、profile_ext、RSSHub 公共实例、freewechat 全文 RSS、自建服务（Backendless）。
4. **「按名称订阅」缺口**：无免登录全网入口；近似为镜像 `/list/all` 名称→hash，或用户粘贴合集/文章链接。

### 本 PR 代码改动（相对 PR #20 的增量）

- `parseFeed`：wechat 镜像 RSS 列表解析派生摘要/封面后**丢弃全文**
- 测试与 `docs/news-sources.md` §4.1/§4.3 同步
- 新调研文档：`docs/superpowers/specs/2026-08-25-wechat-account-stream-research.md`

### 依赖关系

本分支**堆叠在** [#20](https://github.com/t59688/newsnook/pull/20)（`cursor/wechat-mp-parser-e66e`）之上。请先合并 #20，再合本 PR（合入后相对 main 的有效差量即为上述 4 文件）。

## Test plan

- [x] `npm run test:community-sources` / `test:resolve-body` / `test:custom-sources`
- [x] `npm run lint` / `tsc -b`
- [x] 真实 wechat2rss feed 冒烟：2.9MB → 列表约 23KB、0 条携带全文
- [ ] Android 真机住宅网络确认直连正文命中率（#20 遗留）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eaf1b9df-43cc-4606-af1e-0ac3402de66e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eaf1b9df-43cc-4606-af1e-0ac3402de66e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

