### PR TITLE
fix(translation): DeepLX 合并批请求 + 共享节流，修复公共网关 429

### DIFF
--- a/scripts/async-pool.test.ts
+++ b/scripts/async-pool.test.ts
@@ -79,4 +79,26 @@ console.log('Testing mapConcurrent peak concurrency...')
   assert.equal(finished, startedAtSettle, 'no late finishes after settle')
 }
 
+{
+  // 任一任务失败后应停止派发新任务（已在途的照常收尾）
+  let started = 0
+  let finished = 0
+  const items = Array.from({ length: 20 }, (_, i) => i)
+
+  const run = mapConcurrent(items, 3, async (item) => {
+    started += 1
+    if (item === 1) {
+      await sleep(10)
+      throw new Error('boom')
+    }
+    await sleep(30)
+    finished += 1
+  })
+
+  await assert.rejects(() => run, /boom/)
+  await sleep(80)
+  assert.ok(started < items.length, `failure should stop dispatching, started=${started}`)
+  assert.equal(finished, started - 1, 'only the failed task should not finish')
+}
+
 console.log('async-pool tests passed')

--- a/scripts/deeplx-provider.test.ts
+++ b/scripts/deeplx-provider.test.ts
@@ -11,13 +11,24 @@ import {
 // 测试用小步节流：验证行为本身，避免真实退避拖慢用例
 const TEST_MIN_INTERVAL = 40
 const TEST_BACKOFF_BASE = 80
-configureDeepLxThrottleForTests({
-  minIntervalMs: TEST_MIN_INTERVAL,
-  backoffBaseMs: TEST_BACKOFF_BASE,
-  backoffMaxMs: 400,
-  jitterMaxMs: 0,
-  maxRetries: 3,
-})
+// 公共网关档位（api.deeplx.org）：更大间隔、仅 1 次重试
+const TEST_PUBLIC_MIN_INTERVAL = 120
+configureDeepLxThrottleForTests(
+  {
+    minIntervalMs: TEST_MIN_INTERVAL,
+    backoffBaseMs: TEST_BACKOFF_BASE,
+    backoffMaxMs: 400,
+    jitterMaxMs: 0,
+    maxRetries: 3,
+  },
+  {
+    minIntervalMs: TEST_PUBLIC_MIN_INTERVAL,
+    backoffBaseMs: TEST_BACKOFF_BASE,
+    backoffMaxMs: 400,
+    jitterMaxMs: 0,
+    maxRetries: 1,
+  },
+)
 
 // 1. 测试连接（单段文本）只发一个请求；空令牌不发送 Authorization；auto 不带 source_lang
 {
@@ -188,32 +199,39 @@ configureDeepLxThrottleForTests({
   assert.equal(deepLxBackoffMs(0, 1000), 1000) // Retry-After 优先
 }
 
-// 7. 共享节流门：即使并发 >1，请求开始时刻也按最小间隔错开
+// 7. 单段模式合并批：多段按换行合并成一个请求，译文按换行拆回并保持顺序
 {
-  const startTimes: number[] = []
+  const bodies: { text: string }[] = []
   globalThis.fetch = async (_input, init) => {
-    startTimes.push(Date.now())
     const body = JSON.parse(String(init?.body)) as { text: string }
-    return Response.json({ code: 200, data: `LX:${body.text}` })
+    bodies.push(body)
+    const translated = body.text
+      .split('\n')
+      .map((line) => `LX:${line}`)
+      .join('\n')
+    return Response.json({ code: 200, data: translated })
   }
 
   const provider = new DeepLXProvider({
     apiKey: '',
     endpoint: 'https://case7.example/translate',
-    concurrency: 4,
   })
+  const batches: { startIndex: number; translations: string[] }[] = []
   const results = await provider.translate({
     texts: ['a', 'b', 'c', 'd'],
     sourceLanguage: 'en',
     targetLanguage: 'zh-Hans',
+    onBatch: (batchTranslations, startIndex) => {
+      batches.push({ startIndex, translations: batchTranslations })
+    },
   })
 
   assert.deepEqual(results, ['LX:a', 'LX:b', 'LX:c', 'LX:d'])
-  const sorted = [...startTimes].sort((x, y) => x - y)
-  for (let i = 1; i < sorted.length; i += 1) {
-    const gap = sorted[i] - sorted[i - 1]
-    assert.ok(gap >= TEST_MIN_INTERVAL - 20, `请求开始间隔过小：${gap}ms`)
-  }
+  assert.equal(bodies.length, 1, '四段短文本应合并为一个请求')
+  assert.equal(bodies[0].text, 'a\nb\nc\nd')
+  assert.deepEqual(batches, [
+    { startIndex: 0, translations: ['LX:a', 'LX:b', 'LX:c', 'LX:d'] },
+  ])
 }
 
 // 8. 节流门跨 Provider 实例共享（信息流管道 + 测试连接同时进行也不齐射）
@@ -295,6 +313,187 @@ configureDeepLxThrottleForTests({
     (error: unknown) => error instanceof DOMException && error.name === 'AbortError',
   )
   assert.equal(callCount, 1)
+}
+
+// 11. 合并批按段数与字符数分批：超过上限时拆成多个请求
+{
+  const bodies: { text: string }[] = []
+  globalThis.fetch = async (_input, init) => {
+    const body = JSON.parse(String(init?.body)) as { text: string }
+    bodies.push(body)
+    const translated = body.text
+      .split('\n')
+      .map((line) => `译${line.length}`)
+      .join('\n')
+    return Response.json({ code: 200, data: translated })
+  }
+
+  const provider = new DeepLXProvider({
+    apiKey: '',
+    endpoint: 'https://case11.example/translate',
+  })
+
+  // 12 段短文本：按每批 10 段拆成 10 + 2
+  const manyTexts = Array.from({ length: 12 }, (_, i) => `t${i}`)
+  const manyResults = await provider.translate({
+    texts: manyTexts,
+    sourceLanguage: 'en',
+    targetLanguage: 'zh-Hans',
+  })
+  assert.equal(manyResults.length, 12)
+  assert.equal(bodies.length, 2)
+  assert.equal(bodies[0].text.split('\n').length, 10)
+  assert.equal(bodies[1].text.split('\n').length, 2)
+
+  // 两段各 700 字符：合计超过 1200 字符上限，各自独立成请求
+  bodies.length = 0
+  const longA = 'a'.repeat(700)
+  const longB = 'b'.repeat(700)
+  await provider.translate({
+    texts: [longA, longB],
+    sourceLanguage: 'en',
+    targetLanguage: 'zh-Hans',
+  })
+  assert.equal(bodies.length, 2, '超出字符预算的段落不应合并')
+  assert.equal(bodies[0].text, longA)
+  assert.equal(bodies[1].text, longB)
+}
+
+// 12. 合并批译文行数不匹配：回退为逐段请求，结果仍按原顺序对齐
+{
+  const bodies: { text: string }[] = []
+  globalThis.fetch = async (_input, init) => {
+    const body = JSON.parse(String(init?.body)) as { text: string }
+    bodies.push(body)
+    if (body.text.includes('\n')) {
+      // 模拟上游合并了段落：返回行数与请求不一致
+      return Response.json({ code: 200, data: '合并成了一行' })
+    }
+    return Response.json({ code: 200, data: `单:${body.text}` })
+  }
+
+  const provider = new DeepLXProvider({
+    apiKey: '',
+    endpoint: 'https://case12.example/translate',
+  })
+  const results = await provider.translate({
+    texts: ['first', 'second', 'third'],
+    sourceLanguage: 'en',
+    targetLanguage: 'zh-Hans',
+  })
+
+  assert.deepEqual(results, ['单:first', '单:second', '单:third'])
+  // 1 个合并请求 + 3 个逐段回退请求
+  assert.equal(bodies.length, 4)
+}
+
+// 13. 段内换行压平为空格（HTML 渲染等价），不会破坏合并批的换行分隔
+{
+  const bodies: { text: string }[] = []
+  globalThis.fetch = async (_input, init) => {
+    const body = JSON.parse(String(init?.body)) as { text: string }
+    bodies.push(body)
+    const translated = body.text
+      .split('\n')
+      .map((line) => `L:${line}`)
+      .join('\n')
+    return Response.json({ code: 200, data: translated })
+  }
+
+  const provider = new DeepLXProvider({
+    apiKey: '',
+    endpoint: 'https://case13.example/translate',
+  })
+  const results = await provider.translate({
+    texts: ['first line\n  wrapped', 'plain', '', '  '],
+    sourceLanguage: 'en',
+    targetLanguage: 'zh-Hans',
+  })
+
+  assert.equal(bodies.length, 1)
+  assert.equal(bodies[0].text, 'first line wrapped\nplain')
+  // 空白文本不发请求、原样返回空串
+  assert.deepEqual(results, ['L:first line wrapped', 'L:plain', '', ''])
+}
+
+// 14. 端点归一化：路径未以 /translate 结尾时自动补全（路径令牌网关常见漏写）
+{
+  const urls: string[] = []
+  globalThis.fetch = async (input) => {
+    urls.push(String(input))
+    return Response.json({ code: 200, data: '译文' })
+  }
+
+  const cases: [endpoint: string, expected: string][] = [
+    ['https://case14.example/path-token', 'https://case14.example/path-token/translate'],
+    ['https://case14.example/', 'https://case14.example/translate'],
+    ['https://case14.example/nested/translate', 'https://case14.example/nested/translate'],
+  ]
+  for (const [endpoint, expected] of cases) {
+    urls.length = 0
+    const provider = new DeepLXProvider({ apiKey: '', endpoint })
+    await provider.translate({
+      texts: ['Hello'],
+      sourceLanguage: 'auto',
+      targetLanguage: 'zh-Hans',
+    })
+    assert.equal(urls[0], expected, `端点 ${endpoint} 归一化异常`)
+  }
+}
+
+// 15. 公共网关（api.deeplx.org）档位：请求间隔更保守（跨两次调用仍生效）
+{
+  const startTimes: number[] = []
+  globalThis.fetch = async () => {
+    startTimes.push(Date.now())
+    return Response.json({ code: 200, data: '译文' })
+  }
+
+  const provider = new DeepLXProvider({
+    apiKey: '',
+    endpoint: 'https://api.deeplx.org/placeholder-token/translate',
+  })
+  await provider.translate({
+    texts: ['one'],
+    sourceLanguage: 'en',
+    targetLanguage: 'zh-Hans',
+  })
+  await provider.translate({
+    texts: ['two'],
+    sourceLanguage: 'en',
+    targetLanguage: 'zh-Hans',
+  })
+
+  assert.equal(startTimes.length, 2)
+  const gap = startTimes[1] - startTimes[0]
+  assert.ok(
+    gap >= TEST_PUBLIC_MIN_INTERVAL - 20,
+    `公共网关请求间隔应不小于 ${TEST_PUBLIC_MIN_INTERVAL}ms，实际 ${gap}ms`,
+  )
+}
+
+// 16. 公共网关持续 429：只重试 1 次（总请求 2 个），避免重试烧配额
+{
+  let callCount = 0
+  globalThis.fetch = async () => {
+    callCount += 1
+    return Response.json({ code: 429, message: 'Too many requests' }, { status: 429 })
+  }
+
+  const provider = new DeepLXProvider({
+    apiKey: '',
+    endpoint: 'https://api.deeplx.org/placeholder-token/translate',
+  })
+  await assert.rejects(
+    () =>
+      provider.translate({
+        texts: ['Hello World'],
+        sourceLanguage: 'auto',
+        targetLanguage: 'zh-Hans',
+      }),
+    (error: unknown) => isTranslationRateLimitError(error),
+  )
+  assert.equal(callCount, 2)
 }
 
 console.log('deeplx-provider: ok')

--- a/scripts/deeplx-provider.test.ts
+++ b/scripts/deeplx-provider.test.ts
@@ -1,56 +1,300 @@
 import assert from 'node:assert/strict'
 
 import { DeepLXProvider } from '../src/features/translation/providers'
+import {
+  configureDeepLxThrottleForTests,
+  deepLxBackoffMs,
+  isTranslationRateLimitError,
+  parseRetryAfterMs,
+} from '../src/features/translation/rateLimit'
 
-// 1. 测试 /translate 接口的 429 自动退避重试
-let callCount = 0
-globalThis.fetch = async () => {
-  callCount++
-  if (callCount === 1) {
-    // 第一次调用返回 429
-    return Response.json({ code: 429, message: 'Too Many Requests' }, { status: 200 })
+// 测试用小步节流：验证行为本身，避免真实退避拖慢用例
+const TEST_MIN_INTERVAL = 40
+const TEST_BACKOFF_BASE = 80
+configureDeepLxThrottleForTests({
+  minIntervalMs: TEST_MIN_INTERVAL,
+  backoffBaseMs: TEST_BACKOFF_BASE,
+  backoffMaxMs: 400,
+  jitterMaxMs: 0,
+  maxRetries: 3,
+})
+
+// 1. 测试连接（单段文本）只发一个请求；空令牌不发送 Authorization；auto 不带 source_lang
+{
+  const calls: { url: string; body: Record<string, unknown>; authorization: string | null }[] = []
+  globalThis.fetch = async (input, init) => {
+    const headers = new Headers(init?.headers)
+    calls.push({
+      url: String(input),
+      body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+      authorization: headers.get('Authorization'),
+    })
+    return Response.json({ code: 200, data: '世界充满故事。' })
   }
-  // 第二次重试成功
-  return Response.json({ code: 200, data: '测试译文' }, { status: 200 })
-}
 
-const provider = new DeepLXProvider({
-  apiKey: '',
-  endpoint: 'https://deeplx.example.com/translate',
-  concurrency: 1,
-})
+  const provider = new DeepLXProvider({
+    apiKey: '',
+    endpoint: 'https://case1.example/path-token/translate',
+  })
+  const results = await provider.translate({
+    texts: ['The world is full of stories.'],
+    sourceLanguage: 'auto',
+    targetLanguage: 'zh-Hans',
+  })
 
-const results = await provider.translate({
-  texts: ['Hello World'],
-  sourceLanguage: 'auto',
-  targetLanguage: 'zh-Hans',
-})
-
-assert.equal(results[0], '测试译文')
-assert.equal(callCount, 2)
-
-// 2. 测试 /v2/translate 官方兼容模式批量打包
-globalThis.fetch = async (_input, init) => {
-  const body = JSON.parse(String(init?.body))
-  assert.ok(Array.isArray(body.text))
-  assert.equal(body.text.length, 2)
-  return Response.json({
-    code: 200,
-    translations: body.text.map((t: string) => ({ text: `译:${t}` })),
+  assert.deepEqual(results, ['世界充满故事。'])
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].url, 'https://case1.example/path-token/translate')
+  assert.equal(calls[0].authorization, null)
+  assert.deepEqual(calls[0].body, {
+    text: 'The world is full of stories.',
+    target_lang: 'ZH',
   })
 }
 
-const v2Provider = new DeepLXProvider({
-  apiKey: '',
-  endpoint: 'https://deeplx.example.com/v2/translate',
-})
+// 2. HTTP 429 自动退避重试（Bearer 令牌照常携带；等待不少于退避基准）
+{
+  let callCount = 0
+  const startTimes: number[] = []
+  let authorization: string | null = null
+  globalThis.fetch = async (_input, init) => {
+    startTimes.push(Date.now())
+    callCount += 1
+    authorization = new Headers(init?.headers).get('Authorization')
+    if (callCount === 1) {
+      return Response.json({ code: 429, message: 'Too many requests' }, { status: 429 })
+    }
+    return Response.json({ code: 200, data: '测试译文' })
+  }
 
-const v2Results = await v2Provider.translate({
-  texts: ['Item 1', 'Item 2'],
-  sourceLanguage: 'auto',
-  targetLanguage: 'zh-Hans',
-})
+  const provider = new DeepLXProvider({
+    apiKey: 'placeholder-token',
+    endpoint: 'https://case2.example/translate',
+    concurrency: 1,
+  })
+  const results = await provider.translate({
+    texts: ['Hello World'],
+    sourceLanguage: 'auto',
+    targetLanguage: 'zh-Hans',
+  })
 
-assert.deepEqual(v2Results, ['译:Item 1', '译:Item 2'])
+  assert.deepEqual(results, ['测试译文'])
+  assert.equal(callCount, 2)
+  assert.equal(authorization, 'Bearer placeholder-token')
+  const waited = startTimes[1] - startTimes[0]
+  assert.ok(waited >= TEST_BACKOFF_BASE - 10, `429 退避等待过短：${waited}ms`)
+}
+
+// 3. 兼容旧行为：HTTP 200 但 body code=429 同样触发退避重试
+{
+  let callCount = 0
+  globalThis.fetch = async () => {
+    callCount += 1
+    if (callCount === 1) {
+      return Response.json({ code: 429, message: 'Too Many Requests' }, { status: 200 })
+    }
+    return Response.json({ code: 200, data: '测试译文' })
+  }
+
+  const provider = new DeepLXProvider({
+    apiKey: '',
+    endpoint: 'https://case3.example/translate',
+    concurrency: 1,
+  })
+  const results = await provider.translate({
+    texts: ['Hello World'],
+    sourceLanguage: 'auto',
+    targetLanguage: 'zh-Hans',
+  })
+
+  assert.deepEqual(results, ['测试译文'])
+  assert.equal(callCount, 2)
+}
+
+// 4. 持续 429：重试耗尽后抛出限流错误，总请求数 = 1 + maxRetries
+{
+  let callCount = 0
+  globalThis.fetch = async () => {
+    callCount += 1
+    return Response.json({ code: 429, message: 'Too many requests' }, { status: 429 })
+  }
+
+  const provider = new DeepLXProvider({
+    apiKey: '',
+    endpoint: 'https://case4.example/translate',
+    concurrency: 1,
+  })
+  await assert.rejects(
+    () =>
+      provider.translate({
+        texts: ['Hello World'],
+        sourceLanguage: 'auto',
+        targetLanguage: 'zh-Hans',
+      }),
+    (error: unknown) => {
+      assert.ok(isTranslationRateLimitError(error), '应抛出限流错误')
+      assert.match((error as Error).message, /429/)
+      return true
+    },
+  )
+  assert.equal(callCount, 4)
+}
+
+// 5. Retry-After 响应头优先于指数退避
+{
+  let callCount = 0
+  const startTimes: number[] = []
+  globalThis.fetch = async () => {
+    startTimes.push(Date.now())
+    callCount += 1
+    if (callCount === 1) {
+      return Response.json(
+        { code: 429, message: 'Too many requests' },
+        { status: 429, headers: { 'Retry-After': '1' } },
+      )
+    }
+    return Response.json({ code: 200, data: '测试译文' })
+  }
+
+  const provider = new DeepLXProvider({
+    apiKey: '',
+    endpoint: 'https://case5.example/translate',
+    concurrency: 1,
+  })
+  const results = await provider.translate({
+    texts: ['Hello World'],
+    sourceLanguage: 'auto',
+    targetLanguage: 'zh-Hans',
+  })
+
+  assert.deepEqual(results, ['测试译文'])
+  const waited = startTimes[1] - startTimes[0]
+  assert.ok(waited >= 950, `应按 Retry-After 等待约 1 秒，实际 ${waited}ms`)
+}
+
+// 6. 纯函数：Retry-After 解析与退避计算（当前测试配置 jitter=0）
+{
+  assert.equal(parseRetryAfterMs('2'), 2000)
+  assert.equal(parseRetryAfterMs('999999'), 60_000)
+  assert.equal(parseRetryAfterMs('abc'), undefined)
+  assert.equal(parseRetryAfterMs(undefined), undefined)
+  assert.equal(parseRetryAfterMs(null), undefined)
+  const fromDate = parseRetryAfterMs(new Date(Date.now() + 5000).toUTCString())
+  assert.ok(fromDate !== undefined && fromDate > 2000 && fromDate <= 5000, `HTTP 日期解析异常：${fromDate}`)
+
+  assert.equal(deepLxBackoffMs(0), TEST_BACKOFF_BASE)
+  assert.equal(deepLxBackoffMs(1), TEST_BACKOFF_BASE * 2)
+  assert.equal(deepLxBackoffMs(10), 400) // 封顶 backoffMaxMs
+  assert.equal(deepLxBackoffMs(0, 1000), 1000) // Retry-After 优先
+}
+
+// 7. 共享节流门：即使并发 >1，请求开始时刻也按最小间隔错开
+{
+  const startTimes: number[] = []
+  globalThis.fetch = async (_input, init) => {
+    startTimes.push(Date.now())
+    const body = JSON.parse(String(init?.body)) as { text: string }
+    return Response.json({ code: 200, data: `LX:${body.text}` })
+  }
+
+  const provider = new DeepLXProvider({
+    apiKey: '',
+    endpoint: 'https://case7.example/translate',
+    concurrency: 4,
+  })
+  const results = await provider.translate({
+    texts: ['a', 'b', 'c', 'd'],
+    sourceLanguage: 'en',
+    targetLanguage: 'zh-Hans',
+  })
+
+  assert.deepEqual(results, ['LX:a', 'LX:b', 'LX:c', 'LX:d'])
+  const sorted = [...startTimes].sort((x, y) => x - y)
+  for (let i = 1; i < sorted.length; i += 1) {
+    const gap = sorted[i] - sorted[i - 1]
+    assert.ok(gap >= TEST_MIN_INTERVAL - 20, `请求开始间隔过小：${gap}ms`)
+  }
+}
+
+// 8. 节流门跨 Provider 实例共享（信息流管道 + 测试连接同时进行也不齐射）
+{
+  const startTimes: number[] = []
+  globalThis.fetch = async (_input, init) => {
+    startTimes.push(Date.now())
+    const body = JSON.parse(String(init?.body)) as { text: string }
+    return Response.json({ code: 200, data: `LX:${body.text}` })
+  }
+
+  const config = { apiKey: '', endpoint: 'https://case8.example/translate' }
+  const providerA = new DeepLXProvider(config)
+  const providerB = new DeepLXProvider(config)
+  await Promise.all([
+    providerA.translate({ texts: ['one'], sourceLanguage: 'en', targetLanguage: 'zh-Hans' }),
+    providerB.translate({ texts: ['two'], sourceLanguage: 'en', targetLanguage: 'zh-Hans' }),
+  ])
+
+  assert.equal(startTimes.length, 2)
+  const gap = Math.abs(startTimes[1] - startTimes[0])
+  assert.ok(gap >= TEST_MIN_INTERVAL - 20, `跨实例请求间隔过小：${gap}ms`)
+}
+
+// 9. /v2/translate 官方兼容模式：批量打包保留，429 同样退避重试
+{
+  let callCount = 0
+  globalThis.fetch = async (_input, init) => {
+    callCount += 1
+    const body = JSON.parse(String(init?.body)) as { text: string[] }
+    assert.ok(Array.isArray(body.text))
+    assert.equal(body.text.length, 2)
+    if (callCount === 1) {
+      return Response.json({ code: 429, message: 'Too many requests' }, { status: 429 })
+    }
+    return Response.json({
+      code: 200,
+      translations: body.text.map((t: string) => ({ text: `译:${t}` })),
+    })
+  }
+
+  const v2Provider = new DeepLXProvider({
+    apiKey: '',
+    endpoint: 'https://case9.example/v2/translate',
+  })
+  const v2Results = await v2Provider.translate({
+    texts: ['Item 1', 'Item 2'],
+    sourceLanguage: 'auto',
+    targetLanguage: 'zh-Hans',
+  })
+
+  assert.deepEqual(v2Results, ['译:Item 1', '译:Item 2'])
+  assert.equal(callCount, 2)
+}
+
+// 10. 退避等待期间取消：立刻以 AbortError 结束，不再发出请求
+{
+  const controller = new AbortController()
+  let callCount = 0
+  globalThis.fetch = async () => {
+    callCount += 1
+    controller.abort()
+    return Response.json({ code: 429, message: 'Too many requests' }, { status: 429 })
+  }
+
+  const provider = new DeepLXProvider({
+    apiKey: '',
+    endpoint: 'https://case10.example/translate',
+    concurrency: 1,
+  })
+  await assert.rejects(
+    () =>
+      provider.translate({
+        texts: ['Hello World'],
+        sourceLanguage: 'auto',
+        targetLanguage: 'zh-Hans',
+        signal: controller.signal,
+      }),
+    (error: unknown) => error instanceof DOMException && error.name === 'AbortError',
+  )
+  assert.equal(callCount, 1)
+}
 
 console.log('deeplx-provider: ok')

--- a/scripts/translation-service.test.ts
+++ b/scripts/translation-service.test.ts
@@ -3,8 +3,12 @@ import { parseHTML } from 'linkedom'
 
 import { normalizeTranslationPrefs } from '../src/features/translation/config'
 import { DeepLXProvider, GoogleProvider } from '../src/features/translation/providers'
+import { configureDeepLxThrottleForTests } from '../src/features/translation/rateLimit'
 import { TranslationService } from '../src/features/translation/service'
 import type { TranslationProvider } from '../src/features/translation/types'
+
+// DeepLX 共享节流门在测试里压到 1ms，避免用例被真实限速拖慢
+configureDeepLxThrottleForTests({ minIntervalMs: 1, jitterMaxMs: 0 })
 
 const window = parseHTML('<html><body></body></html>')
 Object.assign(globalThis, {

--- a/scripts/translation-service.test.ts
+++ b/scripts/translation-service.test.ts
@@ -121,7 +121,11 @@ globalThis.fetch = async (input, init) => {
     authorization: headers.get('Authorization'),
   })
   const text = typeof body.text === 'string' ? body.text : body.text?.[0] ?? ''
-  return Response.json({ code: 200, data: `LX:${text}` })
+  const translated = text
+    .split('\n')
+    .map((line) => `LX:${line}`)
+    .join('\n')
+  return Response.json({ code: 200, data: translated })
 }
 
 const deepLx = new DeepLXProvider({
@@ -134,11 +138,12 @@ const deepLxResult = await deepLx.translate({
   targetLanguage: 'zh-Hans',
 })
 assert.deepEqual(deepLxResult, ['LX:Hello', 'LX:World'])
-assert.equal(requests.length, 2)
+// 单段模式合并批：两段短文本合并为一个换行分隔的请求
+assert.equal(requests.length, 1)
 assert.equal(requests[0].url, 'https://deeplx.example/path-token/translate')
 assert.equal(requests[0].authorization, null)
 assert.deepEqual(requests[0].body, {
-  text: 'Hello',
+  text: 'Hello\nWorld',
   source_lang: 'EN',
   target_lang: 'ZH',
 })
@@ -219,18 +224,24 @@ assert.ok(googleAutoBody)
 assert.equal('source' in googleAutoBody, false)
 assert.equal(googleAutoBody.target, 'zh-CN')
 
-// Test DeepLX concurrency limit (max 3 concurrent requests)
+// Test DeepLX 合并批串行：25 段短文本 → 3 个请求（10+10+5），且严格串行
 let activeConcurrent = 0
 let maxConcurrentObserved = 0
+let deepLxRequestCount = 0
 globalThis.fetch = async (_input, init) => {
   activeConcurrent++
+  deepLxRequestCount++
   if (activeConcurrent > maxConcurrentObserved) {
     maxConcurrentObserved = activeConcurrent
   }
   const body = JSON.parse(String(init?.body)) as { text?: string }
   await new Promise((r) => setTimeout(r, 10))
   activeConcurrent--
-  return Response.json({ code: 200, data: `LX:${body.text}` })
+  const translated = (body.text ?? '')
+    .split('\n')
+    .map((line) => `LX:${line}`)
+    .join('\n')
+  return Response.json({ code: 200, data: translated })
 }
 
 const deepLxConcurrency = new DeepLXProvider({ apiKey: '', endpoint: 'https://deeplx.example/translate' })
@@ -239,7 +250,8 @@ await deepLxConcurrency.translate({
   sourceLanguage: 'en',
   targetLanguage: 'zh-Hans',
 })
-assert.ok(maxConcurrentObserved <= 3, `Max concurrent requests was ${maxConcurrentObserved}, expected <= 3`)
+assert.equal(deepLxRequestCount, 3, `25 段短文本应合并为 3 个请求，实际 ${deepLxRequestCount}`)
+assert.equal(maxConcurrentObserved, 1, `合并批应严格串行，实际并发 ${maxConcurrentObserved}`)
 
 globalThis.fetch = originalFetch
 

--- a/src/features/translation/config.ts
+++ b/src/features/translation/config.ts
@@ -62,7 +62,7 @@ const DEFAULT_CLOUD: TranslationPrefs['cloud'] = {
   deeplx: {
     apiKey: '',
     endpoint: '',
-    // 公共 DeepLX 服务按突发频率封禁，默认串行最稳妥；自建服务可自行调高
+    // /translate 模式已改为合并批串行，该字段不再生效，仅为兼容旧配置保留
     concurrency: 1,
   },
   openai: {

--- a/src/features/translation/config.ts
+++ b/src/features/translation/config.ts
@@ -62,7 +62,8 @@ const DEFAULT_CLOUD: TranslationPrefs['cloud'] = {
   deeplx: {
     apiKey: '',
     endpoint: '',
-    concurrency: 2,
+    // 公共 DeepLX 服务按突发频率封禁，默认串行最稳妥；自建服务可自行调高
+    concurrency: 1,
   },
   openai: {
     apiKey: '',

--- a/src/features/translation/providers.ts
+++ b/src/features/translation/providers.ts
@@ -1,6 +1,7 @@
 import { Capacitor, CapacitorHttp } from '@capacitor/core'
 
 import { mapConcurrent as sharedMapConcurrent } from '../../lib/asyncPool'
+import { log } from '../../lib/logger'
 import {
   BergamotTranslation,
   isBergamotTranslationAvailable,
@@ -253,12 +254,6 @@ function normalizeOpenAiConcurrency(value: unknown): number {
   return value
 }
 
-function normalizeDeepLxConcurrency(value: unknown): number {
-  if (typeof value !== 'number' || !Number.isFinite(value) || !Number.isInteger(value)) return 1
-  if (value < 1 || value > 5) return 1
-  return value
-}
-
 async function mapConcurrent<T, R>(
   items: T[],
   concurrency: number,
@@ -481,9 +476,15 @@ export class DeepLProvider extends CloudProvider {
   }
 }
 
+/**
+ * 归一化 DeepLX 端点：路径未以 /translate 结尾时自动补全，
+ * 兼容「https://api.deeplx.org/<token>」这类漏写 /translate 的路径令牌配置
+ * （/v1/translate、/v2/translate 都以 /translate 结尾，不受影响）。
+ */
 function deepLxUrl(endpoint: string): URL {
   const url = new URL(endpoint)
-  if (url.pathname === '/' || url.pathname === '') url.pathname = '/translate'
+  const path = url.pathname.replace(/\/+$/, '')
+  url.pathname = /\/translate$/i.test(path) ? path : `${path}/translate`
   return url
 }
 
@@ -500,15 +501,30 @@ interface DeepLxResponse {
 }
 
 const DEEPLX_RATE_LIMIT_MESSAGE =
-  'DeepLX：触发速率限制（429 Too Many Requests），已自动降速重试仍被限流。请稍候再试；若频繁出现，可降低最大并发或关闭「自动翻译外文标题」。'
+  'DeepLX：触发速率限制（429 Too Many Requests），已自动降速重试仍被限流。公共服务按令牌/IP 限频，请稍候再试；若频繁出现，可关闭「自动翻译外文标题」或改用自建服务。'
+
+/**
+ * /translate 单段模式的合并批上限。上游 DeepL 匿名接口对单次请求有约
+ * 1500 字符的硬上限（新版 DeepLX 服务端直接 413 拒绝），留余量取 1200。
+ */
+const DEEPLX_JOIN_ITEMS = 10
+const DEEPLX_JOIN_CHARS = 1200
+
+/** 段内换行在 HTML 渲染中等价于空格；压平后才能用换行作为合并批的段落分隔符。 */
+function flattenLineBreaks(text: string): string {
+  return text.replace(/\s*[\r\n]+\s*/g, ' ')
+}
 
 /**
  * DeepLX 的免费端点与 DeepL 官方 API 不是同一协议：
  * `/translate` 一次接收一个字符串并从 `data` 返回译文；
  * `/v2/translate` 则兼容官方的数组请求与 `translations` 响应。
  *
- * 公共 DeepLX 按突发频率临时封禁 IP/令牌，所以两种模式的请求都经过共享
- * 节流门（跨实例最小间隔），429 时按指数退避重试并优先尊重 Retry-After。
+ * 公共 DeepLX 网关按令牌配额限流、自建实例的上游按突发频率封 IP，
+ * 请求「数量」比间隔更致命。因此 `/translate` 模式将多段文本按换行合并成
+ * 一个请求（DeepLX 服务端整体透传给上游、换行结构原样保留，与主流客户端
+ * 的批量方式一致），并且所有请求经过共享节流门；429 时退避重试并尊重
+ * Retry-After，已知公共网关采用更保守的档位（更慢起步、更少重试）。
  */
 export class DeepLXProvider extends CloudProvider {
   readonly id = 'deeplx' as const
@@ -519,7 +535,7 @@ export class DeepLXProvider extends CloudProvider {
     signal?: AbortSignal,
   ): Promise<JsonResponse> {
     const gate = deepLxGate(url)
-    const { maxRetries } = deepLxThrottleConfig()
+    const { maxRetries } = deepLxThrottleConfig(url)
     for (let attempt = 0; ; attempt += 1) {
       await gate.acquire(signal)
       const response = await postJson(url, body, deepLxHeaders(this.config.apiKey), signal)
@@ -530,11 +546,106 @@ export class DeepLXProvider extends CloudProvider {
       if (!rateLimited) return response
       const retryAfterMs = parseRetryAfterMs(response.headers['retry-after'])
       // 即便重试耗尽也上报冷却，让后续其它请求（信息流/测试连接）继续等待而非齐射
-      gate.reportRateLimit(deepLxBackoffMs(attempt, retryAfterMs))
+      gate.reportRateLimit(deepLxBackoffMs(attempt, retryAfterMs, url))
       if (attempt >= maxRetries) {
         throw new TranslationRateLimitError(DEEPLX_RATE_LIMIT_MESSAGE, retryAfterMs)
       }
     }
+  }
+
+  /** /translate 模式的单请求：一个字符串进、一个字符串出。 */
+  private async translateSingle(
+    url: string,
+    text: string,
+    sourceLang: string | undefined,
+    targetLang: string,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const response = await this.postThrottled(
+      url,
+      {
+        text,
+        ...(sourceLang ? { source_lang: sourceLang } : {}),
+        target_lang: targetLang,
+      },
+      signal,
+    )
+    if (response.status < 200 || response.status >= 300) throw errorMessage('DeepLX', response)
+    const data = response.data as DeepLxResponse
+    if (typeof data.code === 'number' && data.code !== 200) {
+      throw new Error(`DeepLX：${data.message ?? `服务返回错误码 ${data.code}`}`)
+    }
+    if (typeof data.data === 'string') return data.data
+    const officialText = data.translations?.[0]?.text
+    if (officialText) return officialText
+    throw new Error('DeepLX 返回的数据格式不正确')
+  }
+
+  /**
+   * 把一批文本按换行合并成一个 /translate 请求；译文按换行拆回。
+   * 行数对不上时（上游偶发合并/拆分段落）回退为逐段请求，保证结果对齐。
+   */
+  private async translateJoinedBatch(
+    url: string,
+    texts: string[],
+    sourceLang: string | undefined,
+    targetLang: string,
+    signal?: AbortSignal,
+  ): Promise<string[]> {
+    const results = new Array<string>(texts.length).fill('')
+    const sendIndexes: number[] = []
+    const sendTexts: string[] = []
+    texts.forEach((text, index) => {
+      const flattened = flattenLineBreaks(text).trim()
+      if (flattened) {
+        sendIndexes.push(index)
+        sendTexts.push(flattened)
+      }
+    })
+    if (!sendTexts.length) return results
+
+    if (sendTexts.length === 1) {
+      results[sendIndexes[0]] = await this.translateSingle(
+        url,
+        sendTexts[0],
+        sourceLang,
+        targetLang,
+        signal,
+      )
+      return results
+    }
+
+    const joined = await this.translateSingle(
+      url,
+      sendTexts.join('\n'),
+      sourceLang,
+      targetLang,
+      signal,
+    )
+    let parts: string[] | null = joined.split('\n').map((part) => part.trim())
+    if (parts.length !== sendTexts.length) {
+      const nonEmpty = parts.filter((part) => part)
+      parts = nonEmpty.length === sendTexts.length ? nonEmpty : null
+    }
+    if (parts) {
+      parts.forEach((part, i) => {
+        results[sendIndexes[i]] = part
+      })
+      return results
+    }
+
+    // 行数不匹配：逐段回退（仍经共享节流门限速）
+    log.translation.warn('DeepLX joined batch line count mismatch, falling back to per-text requests')
+    for (let i = 0; i < sendTexts.length; i += 1) {
+      results[sendIndexes[i]] = await this.translateSingle(
+        url,
+        sendTexts[i],
+        sourceLang,
+        targetLang,
+        signal,
+      )
+    }
+    return results
   }
 
   async translate(request: TranslationRequest): Promise<string[]> {
@@ -571,36 +682,16 @@ export class DeepLXProvider extends CloudProvider {
       )
     }
 
-    // 单段请求接口模式（/translate）：一段一请求，按配置并发（1~5，默认 1），
-    // 请求开始时刻由共享节流门错开
-    const concurrency = normalizeDeepLxConcurrency(this.config.concurrency)
-    return mapConcurrent(
+    // 单段接口模式（/translate）：按换行把多段合并成一个请求、按批串行推进，
+    // 请求数从「每段一发」降到「每批一发」，适配公共网关的令牌配额
+    return inBatches(
       request.texts,
-      concurrency,
-      async (text) => {
-        const response = await this.postThrottled(
-          url.toString(),
-          {
-            text,
-            ...(sourceLang ? { source_lang: sourceLang } : {}),
-            target_lang: targetLang,
-          },
-          request.signal,
-        )
-        if (response.status < 200 || response.status >= 300) throw errorMessage('DeepLX', response)
-        const data = response.data as DeepLxResponse
-        if (typeof data.code === 'number' && data.code !== 200) {
-          throw new Error(`DeepLX：${data.message ?? `服务返回错误码 ${data.code}`}`)
-        }
-        if (typeof data.data === 'string') return data.data
-        const officialText = data.translations?.[0]?.text
-        if (officialText) return officialText
-        throw new Error('DeepLX 返回的数据格式不正确')
-      },
+      DEEPLX_JOIN_ITEMS,
+      DEEPLX_JOIN_CHARS,
+      async (texts) =>
+        this.translateJoinedBatch(url.toString(), texts, sourceLang, targetLang, request.signal),
       request.signal,
-      (singleTranslated, index) => {
-        request.onBatch?.([singleTranslated], index)
-      },
+      request.onBatch,
     )
   }
 }

--- a/src/features/translation/providers.ts
+++ b/src/features/translation/providers.ts
@@ -14,6 +14,13 @@ import {
   OPENAI_TRANSLATION_STOP,
 } from './openai'
 import { openAiTranslationSystemPrompt, openAiTranslationUserPrompt } from './prompts'
+import {
+  deepLxBackoffMs,
+  deepLxGate,
+  deepLxThrottleConfig,
+  parseRetryAfterMs,
+  TranslationRateLimitError,
+} from './rateLimit'
 import type {
   CloudTranslationConfig,
   CloudTranslationProviderId,
@@ -151,6 +158,17 @@ function decodeHtmlEntities(value: string): string {
 interface JsonResponse {
   status: number
   data: unknown
+  /** 响应头（键已转小写），用于读取 Retry-After 等限流提示 */
+  headers: Record<string, string>
+}
+
+function lowercaseHeaderKeys(headers: Record<string, string> | undefined): Record<string, string> {
+  const result: Record<string, string> = {}
+  if (!headers) return result
+  for (const [key, value] of Object.entries(headers)) {
+    result[key.toLowerCase()] = String(value)
+  }
+  return result
 }
 
 /** CapacitorHttp 在部分 Content-Type 下把 JSON 当字符串返回；Web fetch 则已 parse。 */
@@ -181,7 +199,11 @@ async function postJson(
       connectTimeout: 15000,
       readTimeout: 45000,
     })
-    return { status: response.status, data: coerceHttpJsonData(response.data) }
+    return {
+      status: response.status,
+      data: coerceHttpJsonData(response.data),
+      headers: lowercaseHeaderKeys(response.headers),
+    }
   }
 
   const response = await fetch(url, {
@@ -191,7 +213,11 @@ async function postJson(
     signal,
   })
   const data = (await response.json().catch(() => null)) as unknown
-  return { status: response.status, data: coerceHttpJsonData(data) }
+  const responseHeaders: Record<string, string> = {}
+  response.headers.forEach((value, key) => {
+    responseHeaders[key.toLowerCase()] = value
+  })
+  return { status: response.status, data: coerceHttpJsonData(data), headers: responseHeaders }
 }
 
 function errorMessage(provider: string, response: JsonResponse): Error {
@@ -228,28 +254,9 @@ function normalizeOpenAiConcurrency(value: unknown): number {
 }
 
 function normalizeDeepLxConcurrency(value: unknown): number {
-  if (typeof value !== 'number' || !Number.isFinite(value) || !Number.isInteger(value)) return 2
-  if (value < 1 || value > 5) return 2
+  if (typeof value !== 'number' || !Number.isFinite(value) || !Number.isInteger(value)) return 1
+  if (value < 1 || value > 5) return 1
   return value
-}
-
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (signal?.aborted) {
-      reject(new DOMException('翻译已取消', 'AbortError'))
-      return
-    }
-    const timer = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort)
-      resolve()
-    }, ms)
-    const onAbort = () => {
-      clearTimeout(timer)
-      signal?.removeEventListener('abort', onAbort)
-      reject(new DOMException('翻译已取消', 'AbortError'))
-    }
-    signal?.addEventListener('abort', onAbort, { once: true })
-  })
 }
 
 async function mapConcurrent<T, R>(
@@ -492,19 +499,50 @@ interface DeepLxResponse {
   translations?: { text?: string }[]
 }
 
+const DEEPLX_RATE_LIMIT_MESSAGE =
+  'DeepLX：触发速率限制（429 Too Many Requests），已自动降速重试仍被限流。请稍候再试；若频繁出现，可降低最大并发或关闭「自动翻译外文标题」。'
+
 /**
  * DeepLX 的免费端点与 DeepL 官方 API 不是同一协议：
  * `/translate` 一次接收一个字符串并从 `data` 返回译文；
  * `/v2/translate` 则兼容官方的数组请求与 `translations` 响应。
+ *
+ * 公共 DeepLX 按突发频率临时封禁 IP/令牌，所以两种模式的请求都经过共享
+ * 节流门（跨实例最小间隔），429 时按指数退避重试并优先尊重 Retry-After。
  */
 export class DeepLXProvider extends CloudProvider {
   readonly id = 'deeplx' as const
+
+  private async postThrottled(
+    url: string,
+    body: unknown,
+    signal?: AbortSignal,
+  ): Promise<JsonResponse> {
+    const gate = deepLxGate(url)
+    const { maxRetries } = deepLxThrottleConfig()
+    for (let attempt = 0; ; attempt += 1) {
+      await gate.acquire(signal)
+      const response = await postJson(url, body, deepLxHeaders(this.config.apiKey), signal)
+      const data = response.data as DeepLxResponse | null
+      const rateLimited =
+        response.status === 429 ||
+        (typeof data === 'object' && data !== null && data.code === 429)
+      if (!rateLimited) return response
+      const retryAfterMs = parseRetryAfterMs(response.headers['retry-after'])
+      // 即便重试耗尽也上报冷却，让后续其它请求（信息流/测试连接）继续等待而非齐射
+      gate.reportRateLimit(deepLxBackoffMs(attempt, retryAfterMs))
+      if (attempt >= maxRetries) {
+        throw new TranslationRateLimitError(DEEPLX_RATE_LIMIT_MESSAGE, retryAfterMs)
+      }
+    }
+  }
 
   async translate(request: TranslationRequest): Promise<string[]> {
     assertCloudConfig(this.config, { apiKeyOptional: true })
     const url = deepLxUrl(this.config.endpoint)
     const usesV2 = /\/v2\/translate\/?$/i.test(url.pathname)
     const sourceLang = cloudSourceLanguage(this.id, request.sourceLanguage)
+    const targetLang = language(this.id, request.targetLanguage)
 
     if (usesV2) {
       return inBatches(
@@ -512,14 +550,13 @@ export class DeepLXProvider extends CloudProvider {
         DEFAULT_BATCH_ITEMS,
         DEFAULT_BATCH_CHARS,
         async (texts) => {
-          const response = await postJson(
+          const response = await this.postThrottled(
             url.toString(),
             {
               text: texts,
               ...(sourceLang ? { source_lang: sourceLang } : {}),
-              target_lang: language(this.id, request.targetLanguage),
+              target_lang: targetLang,
             },
-            deepLxHeaders(this.config.apiKey),
             request.signal,
           )
           if (response.status < 200 || response.status >= 300) throw errorMessage('DeepLX', response)
@@ -534,61 +571,31 @@ export class DeepLXProvider extends CloudProvider {
       )
     }
 
-    // 单段请求接口模式（/translate）：以滚动窗口按配置并发（1~5，默认 2）处理，配合错峰节流与 429 退避重试
+    // 单段请求接口模式（/translate）：一段一请求，按配置并发（1~5，默认 1），
+    // 请求开始时刻由共享节流门错开
     const concurrency = normalizeDeepLxConcurrency(this.config.concurrency)
     return mapConcurrent(
       request.texts,
       concurrency,
-      async (text, index) => {
-        // 请求前平滑错峰：错开并发请求（每段间隔 120ms）
-        if (index > 0) {
-          await sleep(120, request.signal)
+      async (text) => {
+        const response = await this.postThrottled(
+          url.toString(),
+          {
+            text,
+            ...(sourceLang ? { source_lang: sourceLang } : {}),
+            target_lang: targetLang,
+          },
+          request.signal,
+        )
+        if (response.status < 200 || response.status >= 300) throw errorMessage('DeepLX', response)
+        const data = response.data as DeepLxResponse
+        if (typeof data.code === 'number' && data.code !== 200) {
+          throw new Error(`DeepLX：${data.message ?? `服务返回错误码 ${data.code}`}`)
         }
-
-        const sendSingleRequest = async (): Promise<{ is429: boolean; text?: string; error?: Error }> => {
-          const response = await postJson(
-            url.toString(),
-            {
-              text,
-              ...(sourceLang ? { source_lang: sourceLang } : {}),
-              target_lang: language(this.id, request.targetLanguage),
-            },
-            deepLxHeaders(this.config.apiKey),
-            request.signal,
-          )
-          if (response.status === 429) {
-            return {
-              is429: true,
-              error: new Error('DeepLX：触发速率限制（429 Too Many Requests），请求过于频繁，请稍候重试或在设置中降低并发。'),
-            }
-          }
-          if (response.status < 200 || response.status >= 300) throw errorMessage('DeepLX', response)
-          const data = response.data as DeepLxResponse
-          if (typeof data.code === 'number' && data.code !== 200) {
-            if (data.code === 429) {
-              return {
-                is429: true,
-                error: new Error('DeepLX：触发速率限制（429 Too Many Requests），请求过于频繁，请稍候重试或在设置中降低并发。'),
-              }
-            }
-            throw new Error(`DeepLX：${data.message ?? `服务返回错误码 ${data.code}`}`)
-          }
-          if (typeof data.data === 'string') return { is429: false, text: data.data }
-          const officialText = data.translations?.[0]?.text
-          if (officialText) return { is429: false, text: officialText }
-          throw new Error('DeepLX 返回的数据格式不正确')
-        }
-
-        let res = await sendSingleRequest()
-        if (res.is429) {
-          // 遭遇 429 速率限制时，自动等待 1.2 秒进行一次退避重试
-          await sleep(1200, request.signal)
-          res = await sendSingleRequest()
-          if (res.is429) {
-            throw res.error ?? new Error('DeepLX：触发速率限制（429 Too Many Requests）')
-          }
-        }
-        return res.text ?? ''
+        if (typeof data.data === 'string') return data.data
+        const officialText = data.translations?.[0]?.text
+        if (officialText) return officialText
+        throw new Error('DeepLX 返回的数据格式不正确')
       },
       request.signal,
       (singleTranslated, index) => {

--- a/src/features/translation/rateLimit.ts
+++ b/src/features/translation/rateLimit.ts
@@ -1,0 +1,151 @@
+/**
+ * DeepLX 共享节流与 429 退避。
+ *
+ * 公共 DeepLX 服务（api.deeplx.org 及自建实例的上游 DeepL）按「短时突发频率」
+ * 临时封禁 IP / 令牌：一旦触发，封禁期内所有请求（包括单条测试连接）都会 429。
+ * 因此所有 DeepLX 请求（阅读器翻译、信息流标题翻译、测试连接）共享同一个
+ * 按端点分组的节流门：
+ * - 相邻两次请求的「开始时刻」至少间隔 minIntervalMs（跨并发 worker、跨实例生效）；
+ * - 收到 429 后整体进入冷却期，冷却结束前所有排队请求一起等待。
+ */
+
+/** 服务端限流（HTTP 429 / body code 429）重试耗尽后抛出的错误。 */
+export class TranslationRateLimitError extends Error {
+  readonly retryAfterMs?: number
+
+  constructor(message: string, retryAfterMs?: number) {
+    super(message)
+    this.name = 'TranslationRateLimitError'
+    this.retryAfterMs = retryAfterMs
+  }
+}
+
+/** 打包边界可能复制类实现，按 name 判定避免 instanceof 失效。 */
+export function isTranslationRateLimitError(
+  error: unknown,
+): error is TranslationRateLimitError {
+  return error instanceof Error && error.name === 'TranslationRateLimitError'
+}
+
+export interface DeepLxThrottleConfig {
+  /** 相邻两次请求「开始时刻」的最小间隔（毫秒） */
+  minIntervalMs: number
+  /** 429 退避基准（按 2^重试次数 指数放大） */
+  backoffBaseMs: number
+  /** 单次退避等待上限 */
+  backoffMaxMs: number
+  /** 退避随机抖动上限（避免多任务同刻恢复形成齐射） */
+  jitterMaxMs: number
+  /** 429 最大重试次数（不含首次请求） */
+  maxRetries: number
+}
+
+const DEFAULT_THROTTLE: DeepLxThrottleConfig = {
+  minIntervalMs: 350,
+  backoffBaseMs: 1500,
+  backoffMaxMs: 15000,
+  jitterMaxMs: 250,
+  maxRetries: 3,
+}
+
+let currentConfig: DeepLxThrottleConfig = { ...DEFAULT_THROTTLE }
+
+export function deepLxThrottleConfig(): Readonly<DeepLxThrottleConfig> {
+  return currentConfig
+}
+
+/** 仅供 scripts/ 测试压缩等待时间；生产代码不要调用。 */
+export function configureDeepLxThrottleForTests(
+  overrides?: Partial<DeepLxThrottleConfig>,
+): void {
+  currentConfig = { ...DEFAULT_THROTTLE, ...overrides }
+}
+
+function abortError(): DOMException {
+  return new DOMException('翻译已取消', 'AbortError')
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(abortError())
+      return
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timer)
+      signal?.removeEventListener('abort', onAbort)
+      reject(abortError())
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+/**
+ * 最小间隔节流门：预约「下一个可用时隙」，把请求开始时刻串行错开。
+ * 时隙先占后等：等待中被取消只会浪费一个时隙，行为偏保守是安全的。
+ */
+export class MinIntervalGate {
+  private nextSlotAt = 0
+
+  async acquire(signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) throw abortError()
+    const now = Date.now()
+    const slot = Math.max(now, this.nextSlotAt)
+    this.nextSlotAt = slot + currentConfig.minIntervalMs
+    if (slot > now) await sleep(slot - now, signal)
+  }
+
+  /** 收到 429：整体冷却，冷却结束前所有排队请求一起等待。 */
+  reportRateLimit(cooldownMs: number): void {
+    const resumeAt = Date.now() + Math.max(0, cooldownMs)
+    if (resumeAt > this.nextSlotAt) this.nextSlotAt = resumeAt
+  }
+}
+
+const gates = new Map<string, MinIntervalGate>()
+
+/** 按端点 origin 取共享节流门（同一 DeepLX 服务的所有调用方共用限额）。 */
+export function deepLxGate(endpoint: string): MinIntervalGate {
+  let key = endpoint
+  try {
+    key = new URL(endpoint).origin
+  } catch {
+    // 非法 URL 时退回原始字符串作为 key
+  }
+  let gate = gates.get(key)
+  if (!gate) {
+    gate = new MinIntervalGate()
+    gates.set(key, gate)
+  }
+  return gate
+}
+
+const RETRY_AFTER_CAP_MS = 60_000
+
+/** 解析 Retry-After 响应头（秒数或 HTTP 日期）；非法返回 undefined。 */
+export function parseRetryAfterMs(value: string | null | undefined): number | undefined {
+  if (!value) return undefined
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+  if (/^\d+$/.test(trimmed)) {
+    return Math.min(Number(trimmed) * 1000, RETRY_AFTER_CAP_MS)
+  }
+  const dateMs = Date.parse(trimmed)
+  if (Number.isNaN(dateMs)) return undefined
+  return Math.min(Math.max(0, dateMs - Date.now()), RETRY_AFTER_CAP_MS)
+}
+
+/** 第 attempt 次重试前的等待：优先服务端 Retry-After，否则指数退避，再加抖动。 */
+export function deepLxBackoffMs(attempt: number, retryAfterMs?: number): number {
+  const config = currentConfig
+  const backoff =
+    retryAfterMs != null && retryAfterMs > 0
+      ? retryAfterMs
+      : Math.min(config.backoffBaseMs * 2 ** attempt, config.backoffMaxMs)
+  const jitter = config.jitterMaxMs > 0 ? Math.floor(Math.random() * config.jitterMaxMs) : 0
+  return backoff + jitter
+}

--- a/src/features/translation/rateLimit.ts
+++ b/src/features/translation/rateLimit.ts
@@ -48,17 +48,44 @@ const DEFAULT_THROTTLE: DeepLxThrottleConfig = {
   maxRetries: 3,
 }
 
-let currentConfig: DeepLxThrottleConfig = { ...DEFAULT_THROTTLE }
+/**
+ * 公共共享网关（如 api.deeplx.org）按令牌配额限流：配额烧完后所有请求
+ * （包括单条测试连接）都会 429 一段时间。对这类主机采用更保守的档位：
+ * 更大的请求间隔压低配额消耗；被限流后只重试一次，避免重试本身继续烧配额。
+ */
+const PUBLIC_GATEWAY_THROTTLE: DeepLxThrottleConfig = {
+  minIntervalMs: 1000,
+  backoffBaseMs: 3000,
+  backoffMaxMs: 15000,
+  jitterMaxMs: 250,
+  maxRetries: 1,
+}
 
-export function deepLxThrottleConfig(): Readonly<DeepLxThrottleConfig> {
-  return currentConfig
+const PUBLIC_GATEWAY_HOSTS = new Set(['api.deeplx.org'])
+
+let currentConfig: DeepLxThrottleConfig = { ...DEFAULT_THROTTLE }
+let publicGatewayConfig: DeepLxThrottleConfig = { ...PUBLIC_GATEWAY_THROTTLE }
+
+/** 端点是否指向已知的公共共享 DeepLX 网关（按令牌配额限流）。 */
+export function isPublicDeepLxGateway(endpoint: string): boolean {
+  try {
+    return PUBLIC_GATEWAY_HOSTS.has(new URL(endpoint).hostname.toLowerCase())
+  } catch {
+    return false
+  }
+}
+
+export function deepLxThrottleConfig(endpoint?: string): Readonly<DeepLxThrottleConfig> {
+  return endpoint && isPublicDeepLxGateway(endpoint) ? publicGatewayConfig : currentConfig
 }
 
 /** 仅供 scripts/ 测试压缩等待时间；生产代码不要调用。 */
 export function configureDeepLxThrottleForTests(
   overrides?: Partial<DeepLxThrottleConfig>,
+  publicGatewayOverrides?: Partial<DeepLxThrottleConfig>,
 ): void {
   currentConfig = { ...DEFAULT_THROTTLE, ...overrides }
+  publicGatewayConfig = { ...PUBLIC_GATEWAY_THROTTLE, ...publicGatewayOverrides }
 }
 
 function abortError(): DOMException {
@@ -90,12 +117,17 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
  */
 export class MinIntervalGate {
   private nextSlotAt = 0
+  private readonly endpoint: string
+
+  constructor(endpoint = '') {
+    this.endpoint = endpoint
+  }
 
   async acquire(signal?: AbortSignal): Promise<void> {
     if (signal?.aborted) throw abortError()
     const now = Date.now()
     const slot = Math.max(now, this.nextSlotAt)
-    this.nextSlotAt = slot + currentConfig.minIntervalMs
+    this.nextSlotAt = slot + deepLxThrottleConfig(this.endpoint).minIntervalMs
     if (slot > now) await sleep(slot - now, signal)
   }
 
@@ -118,7 +150,7 @@ export function deepLxGate(endpoint: string): MinIntervalGate {
   }
   let gate = gates.get(key)
   if (!gate) {
-    gate = new MinIntervalGate()
+    gate = new MinIntervalGate(key)
     gates.set(key, gate)
   }
   return gate
@@ -140,8 +172,12 @@ export function parseRetryAfterMs(value: string | null | undefined): number | un
 }
 
 /** 第 attempt 次重试前的等待：优先服务端 Retry-After，否则指数退避，再加抖动。 */
-export function deepLxBackoffMs(attempt: number, retryAfterMs?: number): number {
-  const config = currentConfig
+export function deepLxBackoffMs(
+  attempt: number,
+  retryAfterMs?: number,
+  endpoint?: string,
+): number {
+  const config = deepLxThrottleConfig(endpoint)
   const backoff =
     retryAfterMs != null && retryAfterMs > 0
       ? retryAfterMs

--- a/src/features/translation/types.ts
+++ b/src/features/translation/types.ts
@@ -26,7 +26,7 @@ export interface CloudTranslationConfig {
   region?: string
   /** OpenAI 兼容提供商必填；其它云端可空。 */
   model?: string
-  /** OpenAI 兼容及 DeepLX 单段模式并发；合法 1–10（DeepLX 建议 1–3），缺省 2。 */
+  /** OpenAI 兼容及 DeepLX 单段模式并发；OpenAI 合法 1–10 缺省 2，DeepLX 合法 1–5 缺省 1。 */
   concurrency?: number
 }
 

--- a/src/features/translation/types.ts
+++ b/src/features/translation/types.ts
@@ -26,7 +26,7 @@ export interface CloudTranslationConfig {
   region?: string
   /** OpenAI 兼容提供商必填；其它云端可空。 */
   model?: string
-  /** OpenAI 兼容及 DeepLX 单段模式并发；OpenAI 合法 1–10 缺省 2，DeepLX 合法 1–5 缺省 1。 */
+  /** OpenAI 兼容提供商并发（合法 1–10，缺省 2）；DeepLX 已改为合并批串行，此字段对其不再生效（兼容旧配置保留）。 */
   concurrency?: number
 }
 

--- a/src/features/translation/useFeedTranslation.ts
+++ b/src/features/translation/useFeedTranslation.ts
@@ -8,6 +8,7 @@ import {
   saveCachedFeedTranslations,
 } from './feedTranslationStorage'
 import { createTranslationProvider } from './providers'
+import { isTranslationRateLimitError } from './rateLimit'
 import { isArticleForeign, isValidTranslationQuality } from './quality'
 import type { Article } from '../../lib/types'
 import {
@@ -176,6 +177,9 @@ export function useFeedTranslation(
           } catch (chunkError) {
             if (controller.signal.aborted) break
             log.translation.warn('Failed to translate chunk:', chunkError)
+            // 命中限流：立即停止本轮管道，避免继续冲击接口导致封禁延长；
+            // 未翻译条目不记失败，留待下次列表变化时自然重试
+            if (isTranslationRateLimitError(chunkError)) break
             for (const art of chunk) {
               failedIdsRef.current.add(art.id)
             }

--- a/src/lib/asyncPool.ts
+++ b/src/lib/asyncPool.ts
@@ -4,6 +4,9 @@
  *
  * abort 时停止派发新任务，但等已开始的任务全部收尾后再抛 AbortError，
  * 避免调用方提前解锁后仍有残留写入。
+ *
+ * 任一任务抛错同样停止派发新任务（整体以首个错误 reject），
+ * 避免调用方已收到失败后，残余 worker 仍继续发起无效请求。
  */
 export async function mapConcurrent<T, R>(
   items: T[],
@@ -19,13 +22,20 @@ export async function mapConcurrent<T, R>(
   }
 
   let nextIndex = 0
+  let failed = false
   const limit = Math.max(1, concurrency)
 
   const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
     while (nextIndex < items.length) {
-      if (signal?.aborted) return
+      if (signal?.aborted || failed) return
       const currentIndex = nextIndex++
-      const res = await fn(items[currentIndex], currentIndex)
+      let res: R
+      try {
+        res = await fn(items[currentIndex], currentIndex)
+      } catch (error) {
+        failed = true
+        throw error
+      }
       results[currentIndex] = res
       onItemDone?.(res, currentIndex)
     }

--- a/src/screens/settings/TranslationScreen.tsx
+++ b/src/screens/settings/TranslationScreen.tsx
@@ -630,28 +630,6 @@ export function TranslationScreen({ prefs, onChange, onBack }: Props) {
                 </button>
               }
             />
-            {prefs.provider === 'deeplx' && (
-              <Field
-                label="最大并发"
-                type="number"
-                min={1}
-                max={5}
-                value={String(activeCloud.concurrency ?? 1)}
-                placeholder="1"
-                onChange={(raw) => {
-                  const trimmed = raw.trim()
-                  if (!trimmed) {
-                    updateCloud({ concurrency: 1 })
-                    return
-                  }
-                  const n = Number(trimmed)
-                  if (!Number.isFinite(n)) return
-                  const truncated = Math.trunc(n)
-                  if (truncated < 1 || truncated > 5) return
-                  updateCloud({ concurrency: truncated })
-                }}
-              />
-            )}
             {prefs.provider === 'azure' && (
               <Field
                 label="AZURE REGION（可选）"

--- a/src/screens/settings/TranslationScreen.tsx
+++ b/src/screens/settings/TranslationScreen.tsx
@@ -636,12 +636,12 @@ export function TranslationScreen({ prefs, onChange, onBack }: Props) {
                 type="number"
                 min={1}
                 max={5}
-                value={String(activeCloud.concurrency ?? 2)}
-                placeholder="2"
+                value={String(activeCloud.concurrency ?? 1)}
+                placeholder="1"
                 onChange={(raw) => {
                   const trimmed = raw.trim()
                   if (!trimmed) {
-                    updateCloud({ concurrency: 2 })
+                    updateCloud({ concurrency: 1 })
                     return
                   }
                   const n = Number(trimmed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

使用 DeepLX（含 `api.deeplx.org` 路径令牌）时，设置页「测试连接」与正文/标题翻译均返回 `429`。相同 endpoint/令牌在其他软件中正常。

用户补充：请求经本地代理 `127.0.0.1:7897`（Clash 等），浏览器 DevTools 可见单次 POST 即 429。

## 根因（两轮结论）

**不只是间隔，更是请求数量。**

1. `/translate` 协议下 NewsNook 原先对每个标题/每个正文文本节点各发一次 POST。信息流 30+ 标题、正文数十～上百段，即使 350ms 节流也很快烧完公共网关配额。
2. 配额耗尽后网关进入临时封禁窗口，窗口内**任意**单次请求（含「测试连接」）都 429——表现为「测一下就挂」。其他客户端通常把多行文本合并成一次请求，同令牌仍可用。
3. 已实测：api.deeplx.org 对带 `Origin` 的浏览器 POST 可正常 200，**排除 CORS/浏览器指纹导致 429**；伪造令牌返回 401，说明用户遇到的 429 是有效令牌被限流。

## 改动

### 第一轮（节流）
- 按 endpoint origin 共享节流门、429 冷却、`Retry-After`、指数退避
- DeepLX 默认并发 1；信息流遇限流本轮停止；`asyncPool` 失败后停止派发

### 第二轮（降请求量，针对「依然 429」）
- `/translate`：**多段合并为少量 POST**（压平段内换行后用 `\n` 拼接，每批 ≤10 段 / ≤1200 字符，串行）；译文按行拆回，行数不匹配则回退逐段（仍走节流门）
- 公共网关 `api.deeplx.org`：间隔 1s、429 最多再试 1 次（避免测试连接连打 4 次）
- 端点缺 `/translate` 时自动补全；设置页移除已无效的 DeepLX「最大并发」输入

## 验证

- `npm run test:deeplx`（含合并批/回退/公共网关档位等）
- `npm run test:translation` / `test:feed-translation` / `test:async-pool` / `test:openai`
- `npm run lint`、`npx tsc -b`

## 使用注意

若令牌当前仍在封禁窗口，需等待窗口过期后再测；首次成功后应明显少于以往的请求次数。请勿在 Issue/评论中粘贴真实 API 令牌。

## 残留风险

公共实例配额未公开；上游偶发合并段落会触发逐段回退；极少数非标准路径的自建反代可能受端点补全影响。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-983a7a4a-032b-48a3-bfe7-140fc4461c98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-983a7a4a-032b-48a3-bfe7-140fc4461c98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

