### PR TITLE
fix(translation): 消除列表翻译重复请求与阅读器状态残留

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "1.6.7",
+  "version": "1.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "1.6.7",
+      "version": "1.6.6",
       "dependencies": {
         "@capacitor-community/media": "^9.1.0",
         "@capacitor/android": "8.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "1.6.6",
+      "version": "1.6.7",
       "dependencies": {
         "@capacitor-community/media": "^9.1.0",
         "@capacitor/android": "8.4.2",

--- a/scripts/deeplx-provider.test.ts
+++ b/scripts/deeplx-provider.test.ts
@@ -53,4 +53,25 @@ const v2Results = await v2Provider.translate({
 
 assert.deepEqual(v2Results, ['译:Item 1', '译:Item 2'])
 
+// 3. 单段接口模式下，同一次调用内重复文本只请求一次，结果按原顺序展开
+let singleCalls = 0
+globalThis.fetch = async (_input, init) => {
+  singleCalls++
+  const body = JSON.parse(String(init?.body)) as { text?: string }
+  return Response.json({ code: 200, data: `LX:${body.text}` })
+}
+
+const dedupProvider = new DeepLXProvider({
+  apiKey: '',
+  endpoint: 'https://deeplx.example.com/translate',
+  concurrency: 2,
+})
+const dedupResults = await dedupProvider.translate({
+  texts: ['Repeat me', 'Something else', 'Repeat me'],
+  sourceLanguage: 'auto',
+  targetLanguage: 'zh-Hans',
+})
+assert.deepEqual(dedupResults, ['LX:Repeat me', 'LX:Something else', 'LX:Repeat me'])
+assert.equal(singleCalls, 2)
+
 console.log('deeplx-provider: ok')

--- a/scripts/feed-translation.test.ts
+++ b/scripts/feed-translation.test.ts
@@ -107,6 +107,12 @@ assert.equal(
   false,
 )
 
+// 短中文标题 + 空摘要：样本不足触发检测回退，不应被误判为外文（否则已是目标语言仍请求）
+assert.equal(isArticleForeign({ title: '中美经贸会谈落幕', summary: '' }, 'zh-Hans'), false)
+
+// 短外文标题仍应命中翻译队列
+assert.equal(isArticleForeign({ title: 'Fed cuts rates', summary: '' }, 'zh-Hans'), true)
+
 // 6. Test isValidTranslationQuality (Rejecting partial / corrupted translations)
 // Bad case 1: "Wang Gungwu on the lessons of Chinese history and the Cold War" -> "王 gunshot on Chinese history and the Cold War"
 assert.equal(

--- a/scripts/feed-translation.test.ts
+++ b/scripts/feed-translation.test.ts
@@ -8,6 +8,9 @@ import {
 import { detectLanguage } from '../src/features/translation/detectLanguage'
 import { DEFAULT_TRANSLATION_PREFS, normalizeTranslationPrefs } from '../src/features/translation/config'
 import { isArticleForeign, isValidTranslationQuality } from '../src/features/translation/quality'
+import { collectFeedTranslationWork } from '../src/features/translation/useFeedTranslation'
+import type { TranslatedFeedItem } from '../src/features/translation/types'
+import type { Article } from '../src/lib/types'
 
 // 1. Mock LocalStorage for node environment
 const memoryStore = new Map<string, string>()
@@ -143,6 +146,64 @@ assert.equal(
     "zh-Hans",
   ),
   true,
+)
+
+// 7. collectFeedTranslationWork：已在状态 / 已持久缓存 / 会话失败 / 非外文的条目都不再进入待翻译队列
+const makeArticle = (id: string, title: string): Article => ({
+  id,
+  title,
+  summary: '',
+  publishedAt: Date.now(),
+  hasRealDate: true,
+  sourceId: 'src-test',
+  sourceName: 'Test',
+  sourceLabel: 'Test',
+  sourceGroup: 'intl',
+  originUrl: `https://example.com/${id}`,
+})
+
+clearFeedTranslations()
+saveCachedFeedTranslation({
+  articleId: 'art-cached',
+  title: '已缓存的中文译文标题',
+  targetLanguage: 'zh-Hans',
+  translatedAt: Date.now(),
+})
+
+const stateMap = new Map<string, TranslatedFeedItem>([
+  [
+    'art-in-state',
+    { articleId: 'art-in-state', title: '已在状态里的译文', targetLanguage: 'zh-Hans', translatedAt: Date.now() },
+  ],
+  [
+    'art-stale-lang',
+    { articleId: 'art-stale-lang', title: '旧语言译文', targetLanguage: 'en', translatedAt: Date.now() },
+  ],
+])
+
+const work = collectFeedTranslationWork(
+  [
+    makeArticle('art-cached', 'Cached headline should reuse persistent cache'),
+    makeArticle('art-fresh', 'Fresh headline still needs a translation request'),
+    makeArticle('art-failed', 'Failed headline must be skipped this session'),
+    makeArticle('art-zh', '中文标题不进入翻译队列'),
+    makeArticle('art-in-state', 'Already translated headline in state'),
+    makeArticle('art-stale-lang', 'State entry holds wrong target language'),
+  ],
+  stateMap,
+  new Set(['art-failed']),
+  'zh-Hans',
+)
+
+// 命中持久缓存的直接复用，不再发请求
+assert.deepEqual(
+  work.cachedHits.map((item) => item.articleId),
+  ['art-cached'],
+)
+// 只有真正没有译文的外文标题才需要联网（状态里语言不匹配的也要重翻）
+assert.deepEqual(
+  work.needed.map((item) => item.id),
+  ['art-fresh', 'art-stale-lang'],
 )
 
 console.log('feed-translation: ok')

--- a/scripts/openai-provider.test.ts
+++ b/scripts/openai-provider.test.ts
@@ -335,6 +335,45 @@ await providerFive.translate({ texts: many, sourceLanguage: 'en', targetLanguage
 assert.ok(maxActive <= 5, `custom max concurrent ${maxActive}`)
 assert.ok(maxActive >= 2, `expected some parallelism, got ${maxActive}`)
 
+// 同一次调用内重复文本只请求一次，结果按原顺序展开，onBatch 仍逐条回调
+let dedupCalls = 0
+globalThis.fetch = async (_input, init) => {
+  dedupCalls++
+  const body = JSON.parse(String(init?.body)) as {
+    messages: { role: string; content: string }[]
+  }
+  const user = body.messages.find((m) => m.role === 'user')?.content ?? ''
+  const plain = user.match(/^原文：\n([\s\S]+)$/)
+  await new Promise((r) => setTimeout(r, 5))
+  return Response.json({ choices: [{ message: { content: `AI:${plain?.[1] ?? user}` } }] })
+}
+const dedupIndexes: number[] = []
+const dedupResult = await providerFive.translate({
+  texts: ['Same caption', 'Body text', 'Same caption'],
+  sourceLanguage: 'en',
+  targetLanguage: 'zh-Hans',
+  onBatch: (_batch, startIndex) => {
+    dedupIndexes.push(startIndex)
+  },
+})
+assert.deepEqual(dedupResult, ['AI:Same caption', 'AI:Body text', 'AI:Same caption'])
+assert.equal(dedupCalls, 2)
+assert.deepEqual(
+  dedupIndexes.sort((a, b) => a - b),
+  [0, 1, 2],
+)
+
+// 文本相同但场景不同（headline vs paragraph）不去重，仍各自请求
+dedupCalls = 0
+const kindSplit = await providerFive.translate({
+  texts: ['Same words', 'Same words'],
+  textKinds: ['headline', 'paragraph'],
+  sourceLanguage: 'en',
+  targetLanguage: 'zh-Hans',
+})
+assert.deepEqual(kindSplit, ['AI:Same words', 'AI:Same words'])
+assert.equal(dedupCalls, 2)
+
 globalThis.fetch = originalFetch
 
 console.log('openai-provider: ok')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -540,6 +540,15 @@ export default function App() {
     [availableArticles, categorySourceSet],
   )
 
+  /** 单源筛选时保持数组引用稳定：每次渲染现算会让列表翻译等依赖 articles 的 effect 反复中止重启 */
+  const displayedArticles = useMemo(
+    () =>
+      categoryFilterSourceId
+        ? articles.filter((item) => item.sourceId === categoryFilterSourceId)
+        : articles,
+    [articles, categoryFilterSourceId],
+  )
+
   const articlesForCategory = useCallback(
     (id: CategoryId) => {
       const ids = new Set(sourceIdsForCategoryWithPrefs(id, prefs, enabledIds))
@@ -1175,9 +1184,6 @@ export default function App() {
     const activeFilterSource = categoryFilterSourceId
       ? findSource(categoryFilterSourceId, prefs.customSources)
       : null
-    const displayedArticles = categoryFilterSourceId
-      ? articles.filter((item) => item.sourceId === categoryFilterSourceId)
-      : articles
 
     return (
       <FeedScreen

--- a/src/features/translation/providers.ts
+++ b/src/features/translation/providers.ts
@@ -22,6 +22,7 @@ import type {
   TranslationProviderId,
   TranslationRequest,
   TranslationSourceLanguage,
+  TranslationTextKind,
 } from './types'
 
 const LANGUAGE_MAP: Record<
@@ -536,59 +537,70 @@ export class DeepLXProvider extends CloudProvider {
 
     // 单段请求接口模式（/translate）：以滚动窗口按配置并发（1~5，默认 2）处理，配合错峰节流与 429 退避重试
     const concurrency = normalizeDeepLxConcurrency(this.config.concurrency)
-    return mapConcurrent(
-      request.texts,
-      concurrency,
-      async (text, index) => {
-        // 请求前平滑错峰：错开并发请求（每段间隔 120ms）
-        if (index > 0) {
-          await sleep(120, request.signal)
-        }
+    // 同一次调用内相同文本只发一次请求（正文里重复的 caption/短语共享在途结果）
+    const inflightByText = new Map<string, Promise<string>>()
+    const translateSingle = async (text: string, index: number): Promise<string> => {
+      // 请求前平滑错峰：错开并发请求（每段间隔 120ms）
+      if (index > 0) {
+        await sleep(120, request.signal)
+      }
 
-        const sendSingleRequest = async (): Promise<{ is429: boolean; text?: string; error?: Error }> => {
-          const response = await postJson(
-            url.toString(),
-            {
-              text,
-              ...(sourceLang ? { source_lang: sourceLang } : {}),
-              target_lang: language(this.id, request.targetLanguage),
-            },
-            deepLxHeaders(this.config.apiKey),
-            request.signal,
-          )
-          if (response.status === 429) {
+      const sendSingleRequest = async (): Promise<{ is429: boolean; text?: string; error?: Error }> => {
+        const response = await postJson(
+          url.toString(),
+          {
+            text,
+            ...(sourceLang ? { source_lang: sourceLang } : {}),
+            target_lang: language(this.id, request.targetLanguage),
+          },
+          deepLxHeaders(this.config.apiKey),
+          request.signal,
+        )
+        if (response.status === 429) {
+          return {
+            is429: true,
+            error: new Error('DeepLX：触发速率限制（429 Too Many Requests），请求过于频繁，请稍候重试或在设置中降低并发。'),
+          }
+        }
+        if (response.status < 200 || response.status >= 300) throw errorMessage('DeepLX', response)
+        const data = response.data as DeepLxResponse
+        if (typeof data.code === 'number' && data.code !== 200) {
+          if (data.code === 429) {
             return {
               is429: true,
               error: new Error('DeepLX：触发速率限制（429 Too Many Requests），请求过于频繁，请稍候重试或在设置中降低并发。'),
             }
           }
-          if (response.status < 200 || response.status >= 300) throw errorMessage('DeepLX', response)
-          const data = response.data as DeepLxResponse
-          if (typeof data.code === 'number' && data.code !== 200) {
-            if (data.code === 429) {
-              return {
-                is429: true,
-                error: new Error('DeepLX：触发速率限制（429 Too Many Requests），请求过于频繁，请稍候重试或在设置中降低并发。'),
-              }
-            }
-            throw new Error(`DeepLX：${data.message ?? `服务返回错误码 ${data.code}`}`)
-          }
-          if (typeof data.data === 'string') return { is429: false, text: data.data }
-          const officialText = data.translations?.[0]?.text
-          if (officialText) return { is429: false, text: officialText }
-          throw new Error('DeepLX 返回的数据格式不正确')
+          throw new Error(`DeepLX：${data.message ?? `服务返回错误码 ${data.code}`}`)
         }
+        if (typeof data.data === 'string') return { is429: false, text: data.data }
+        const officialText = data.translations?.[0]?.text
+        if (officialText) return { is429: false, text: officialText }
+        throw new Error('DeepLX 返回的数据格式不正确')
+      }
 
-        let res = await sendSingleRequest()
+      let res = await sendSingleRequest()
+      if (res.is429) {
+        // 遭遇 429 速率限制时，自动等待 1.2 秒进行一次退避重试
+        await sleep(1200, request.signal)
+        res = await sendSingleRequest()
         if (res.is429) {
-          // 遭遇 429 速率限制时，自动等待 1.2 秒进行一次退避重试
-          await sleep(1200, request.signal)
-          res = await sendSingleRequest()
-          if (res.is429) {
-            throw res.error ?? new Error('DeepLX：触发速率限制（429 Too Many Requests）')
-          }
+          throw res.error ?? new Error('DeepLX：触发速率限制（429 Too Many Requests）')
         }
-        return res.text ?? ''
+      }
+      return res.text ?? ''
+    }
+
+    return mapConcurrent(
+      request.texts,
+      concurrency,
+      (text, index) => {
+        let pending = inflightByText.get(text)
+        if (!pending) {
+          pending = translateSingle(text, index)
+          inflightByText.set(text, pending)
+        }
+        return pending
       },
       request.signal,
       (singleTranslated, index) => {
@@ -611,42 +623,54 @@ export class OpenAiProvider extends CloudProvider {
       throw new Error('AI 翻译：textKinds 与 texts 长度不一致')
     }
 
+    // 同一次调用内「文本 + 场景」相同的段落只发一次请求，重复段共享在途结果
+    const inflightByKey = new Map<string, Promise<string>>()
+    const translateSingle = async (text: string, kind: TranslationTextKind): Promise<string> => {
+      const system = openAiTranslationSystemPrompt(
+        request.sourceLanguage,
+        request.targetLanguage,
+        kind,
+        model,
+      )
+      const userPrompt = openAiTranslationUserPrompt(text, request.targetLanguage, kind, model)
+      const messages: { role: 'system' | 'user'; content: string }[] = []
+      if (system) messages.push({ role: 'system', content: system })
+      messages.push({ role: 'user', content: userPrompt })
+      const response = await postJson(
+        url,
+        {
+          model,
+          // Mid-low: fluent news prose without inventing proper-noun transliterations.
+          temperature: 0.6,
+          stream: false,
+          stop: OPENAI_TRANSLATION_STOP,
+          messages,
+        },
+        { Authorization: `Bearer ${this.config.apiKey.trim()}` },
+        request.signal,
+      )
+      if (response.status < 200 || response.status >= 300) {
+        throw errorMessage('AI 翻译', response)
+      }
+      const content = extractOpenAiChatContent(response.data)
+      if (typeof content !== 'string' || !content.trim()) {
+        throw new Error('AI 翻译：返回内容为空')
+      }
+      return cleanOpenAiTranslation(content)
+    }
+
     return mapConcurrent(
       request.texts,
       concurrency,
-      async (text, index) => {
+      (text, index) => {
         const kind = request.textKinds?.[index] ?? 'paragraph'
-        const system = openAiTranslationSystemPrompt(
-          request.sourceLanguage,
-          request.targetLanguage,
-          kind,
-          model,
-        )
-        const userPrompt = openAiTranslationUserPrompt(text, request.targetLanguage, kind, model)
-        const messages: { role: 'system' | 'user'; content: string }[] = []
-        if (system) messages.push({ role: 'system', content: system })
-        messages.push({ role: 'user', content: userPrompt })
-        const response = await postJson(
-          url,
-          {
-            model,
-            // Mid-low: fluent news prose without inventing proper-noun transliterations.
-            temperature: 0.6,
-            stream: false,
-            stop: OPENAI_TRANSLATION_STOP,
-            messages,
-          },
-          { Authorization: `Bearer ${this.config.apiKey.trim()}` },
-          request.signal,
-        )
-        if (response.status < 200 || response.status >= 300) {
-          throw errorMessage('AI 翻译', response)
+        const key = `${kind}\u0000${text}`
+        let pending = inflightByKey.get(key)
+        if (!pending) {
+          pending = translateSingle(text, kind)
+          inflightByKey.set(key, pending)
         }
-        const content = extractOpenAiChatContent(response.data)
-        if (typeof content !== 'string' || !content.trim()) {
-          throw new Error('AI 翻译：返回内容为空')
-        }
-        return cleanOpenAiTranslation(content)
+        return pending
       },
       request.signal,
       (singleTranslated, index) => {

--- a/src/features/translation/quality.ts
+++ b/src/features/translation/quality.ts
@@ -42,6 +42,17 @@ export function isArticleForeign(
   // 2. 结合标题与摘要整体检测
   const combined = `${title} ${summary}`.trim()
   const detected = detectLanguage(combined)
+
+  if (detected.usedFallback) {
+    // 样本过短置信不足时的回退是英语，不能据此当成外文——
+    // 否则「中文短标题 + 空摘要」会被误判并对已是目标语言的文本发起翻译请求。
+    // 按字符构成兜底：仅目标为中文且样本明显是拉丁文时才进翻译队列。
+    if (!isTargetChinese) return false
+    const han = (combined.match(/[\u4e00-\u9fa5\u3400-\u4dbf]/g) || []).length
+    const latin = (combined.match(/[a-zA-Z]/g) || []).length
+    return latin >= 6 && han <= 2
+  }
+
   const isDetectedChinese = detected.language === 'zh-Hans' || detected.language === 'zh-Hant'
 
   if (isTargetChinese) {

--- a/src/features/translation/useFeedTranslation.ts
+++ b/src/features/translation/useFeedTranslation.ts
@@ -4,6 +4,7 @@ import { log } from '../../lib/logger'
 import { cleanOpenAiTranslation } from './openai'
 import { normalizeChineseVariant } from './chineseVariant'
 import {
+  loadCachedFeedTranslation,
   loadCachedFeedTranslations,
   saveCachedFeedTranslations,
 } from './feedTranslationStorage'
@@ -13,12 +14,42 @@ import type { Article } from '../../lib/types'
 import {
   isLocalTranslationProviderId,
   type TranslatedFeedItem,
+  type TranslationLanguage,
   type TranslationPrefs,
 } from './types'
 
 export { isArticleForeign }
 
 const BATCH_SIZE = 8
+
+/**
+ * 从当前列表挑出真正需要联网翻译的条目。
+ * 已在内存状态、会话内失败或非外文的先跳过；剩下的再查持久缓存——
+ * React 状态合并是异步的，缓存合并 effect 的 setState 落地前管道 effect 就会执行，
+ * 不查缓存会把 localStorage 里已有译文（含上一轮被中断时落盘的结果）重新交给翻译 API。
+ */
+export function collectFeedTranslationWork(
+  articles: Article[],
+  translated: ReadonlyMap<string, TranslatedFeedItem>,
+  failedIds: ReadonlySet<string>,
+  targetLanguage: TranslationLanguage,
+): { needed: Article[]; cachedHits: TranslatedFeedItem[] } {
+  const needed: Article[] = []
+  const cachedHits: TranslatedFeedItem[] = []
+  for (let i = 0; i < articles.length; i += 1) {
+    const art = articles[i]
+    if (translated.get(art.id)?.targetLanguage === targetLanguage) continue
+    if (failedIds.has(art.id)) continue
+    if (!isArticleForeign(art, targetLanguage)) continue
+    const cached = loadCachedFeedTranslation(art.id, targetLanguage)
+    if (cached) {
+      cachedHits.push(cached)
+      continue
+    }
+    needed.push(art)
+  }
+  return { needed, cachedHits }
+}
 
 export function useFeedTranslation(
   articles: Article[],
@@ -79,22 +110,20 @@ export function useFeedTranslation(
       return
     }
 
-    // 筛选出：属于外文、尚未有译文、且未在当前会话失败的待翻译文章
-    const neededArticles: Article[] = []
-    for (let i = 0; i < articles.length; i += 1) {
-      const art = articles[i]
-      if (
-        translationsRef.current.has(art.id) &&
-        translationsRef.current.get(art.id)?.targetLanguage === targetLanguage
-      ) {
-        continue
-      }
-      if (failedIdsRef.current.has(art.id)) {
-        continue
-      }
-      if (isArticleForeign(art, targetLanguage)) {
-        neededArticles.push(art)
-      }
+    // 筛选出：属于外文、尚未有译文（状态或持久缓存）、且未在当前会话失败的待翻译文章
+    const { needed: neededArticles, cachedHits } = collectFeedTranslationWork(
+      articles,
+      translationsRef.current,
+      failedIdsRef.current,
+      targetLanguage,
+    )
+
+    if (cachedHits.length) {
+      setTranslations((prev) => {
+        const next = new Map(prev)
+        for (const item of cachedHits) next.set(item.articleId, item)
+        return next
+      })
     }
 
     if (!neededArticles.length) {
@@ -112,8 +141,12 @@ export function useFeedTranslation(
       : prefs.cloud[prefs.provider]
     const provider = createTranslationProvider(prefs.provider, config)
 
+    /** 本轮已处理过的条目，避免 onBatch 与最终结果循环对同一译文双重校验与写入 */
+    const appliedIds = new Set<string>()
+
     const applyProgressiveUpdate = (art: Article, rawText: string) => {
-      if (!art || !rawText) return
+      if (!art || !rawText || appliedIds.has(art.id)) return
+      appliedIds.add(art.id)
       const trimmed = cleanOpenAiTranslation(rawText)
 
       // 质量与完整性校验：拦截严重残缺、中英混乱或翻译直通失败
@@ -131,7 +164,9 @@ export function useFeedTranslation(
         targetLanguage,
         translatedAt: Date.now(),
       }
+      // 即使本轮已被取消也把有效译文落盘：重启的管道据缓存跳过，不再重复请求同一标题
       saveCachedFeedTranslations([item])
+      if (controller.signal.aborted) return
       setTranslations((prev) => {
         const next = new Map(prev)
         next.set(art.id, item)
@@ -154,7 +189,6 @@ export function useFeedTranslation(
               targetLanguage: prefs.targetLanguage,
               signal: controller.signal,
               onBatch: (batchTranslations, startIndex) => {
-                if (controller.signal.aborted) return
                 for (let i = 0; i < batchTranslations.length; i += 1) {
                   const art = chunk[startIndex + i]
                   const transText = batchTranslations[i]
@@ -177,7 +211,8 @@ export function useFeedTranslation(
             if (controller.signal.aborted) break
             log.translation.warn('Failed to translate chunk:', chunkError)
             for (const art of chunk) {
-              failedIdsRef.current.add(art.id)
+              // 批内已成功落地的条目不算失败，保留后续会话重用缓存的资格
+              if (!appliedIds.has(art.id)) failedIdsRef.current.add(art.id)
             }
           }
         }

--- a/src/screens/ReaderScreen.tsx
+++ b/src/screens/ReaderScreen.tsx
@@ -1012,17 +1012,18 @@ export function ReaderScreen({
   const toggleTranslation = async () => {
     if (loadState !== 'ready') return
 
-    // 1. 如果正在翻译中，点击取消本次翻译并切回原文
+    // 1. 如果正在翻译中，点击取消本次翻译并切回原文；丢弃半成品，避免之后被当成完整译文直接展示
     if (translationState === 'loading') {
       cancelTranslation()
+      setTranslated(null)
       setTranslationState('idle')
       setTranslationError('')
       setShowTranslation(false)
       return
     }
 
-    // 2. 如果当前正在显示译文（或处于报错状态），点击直接切回原文
-    if (showTranslation) {
+    // 2. 如果当前正在显示译文，点击直接切回原文；报错状态除外——那时按钮语义是「重试」，落到下方重新翻译
+    if (showTranslation && translationState !== 'error') {
       setShowTranslation(false)
       setTranslationError('')
       return
@@ -1046,6 +1047,7 @@ export function ReaderScreen({
     translationTimeoutRef.current = setTimeout(() => {
       if (translationAbortRef.current !== controller) return
       controller.abort()
+      setTranslated(null)
       setTranslationError('翻译等待超过 60 秒，请检查网络或翻译服务后重试。')
       setTranslationState('error')
     }, TRANSLATION_TIMEOUT_MS)
@@ -1082,6 +1084,8 @@ export function ReaderScreen({
       setTranslationState('idle')
     } catch (error) {
       if (controller.signal.aborted) return
+      // 未完成的部分译文不保留：否则错误清除后会被当成完整译文直接展示
+      setTranslated(null)
       const raw = error instanceof Error ? error.message : '翻译失败'
       setTranslationError(
         raw.includes('MODEL_NOT_DOWNLOADED')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

审查翻译模块后修复列表翻译风暴、重复 API 请求与阅读器半成品状态等问题。

## 主要修复

- **Feed 列表**：缓存命中的标题不再重复打 API；abort 后仍落盘已完成译文；稳定 `displayedArticles` 引用，避免 effect 反复 abort/重启
- **Provider**：OpenAI / DeepLX 单段模式对同次调用内重复文本去重共享在途请求
- **语言检测**：短样本回退时不再默认判外文，避免中文短标题误请求
- **阅读器**：取消/报错/超时清空半成品；报错态真正重新翻译

## 验证

- `npm run test:translation` / `test:feed-translation` / `test:deeplx` / `test:openai` / `test:detect-language` / `test:chinese-variant` / `test:async-pool` 通过
- `npm run lint`、`npx tsc -b` 通过

## 模型

云端子代理实际使用：`claude-fable-5-thinking-xhigh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-931bdbd8-9c6c-43f5-8abb-6ee435d1e9ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-931bdbd8-9c6c-43f5-8abb-6ee435d1e9ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

