### PR TITLE
fix(auth): resolve GitHub link-social state_mismatch on Android

### DIFF
--- a/cloud/src/auth.ts
+++ b/cloud/src/auth.ts
@@ -32,6 +32,9 @@ export interface CreateAuthOptions {
 /** 一次性 token 的有效期（分钟）；只够浏览器跳回 App 完成一次交换 */
 export const MOBILE_OTT_EXPIRES_IN_MINUTES = 3
 
+/** OAuth state Cookie 的存活秒数，与 Better Auth 写进 verification 的 10 分钟一致 */
+export const OAUTH_STATE_MAX_AGE_SECONDS = 600
+
 /**
  * 返回类型刻意保持推断：Better Auth 的 `api` 形状由启用的插件决定，
  * 写成 `Auth<BetterAuthOptions>` 会把 bearer / one-time-token 的端点擦掉。
@@ -131,6 +134,12 @@ export function createAuth(options: CreateAuthOptions) {
         httpOnly: true,
         secure: config.betterAuthUrl.startsWith('https://'),
         sameSite: 'lax',
+      },
+      cookies: {
+        // state Cookie 默认只活 5 分钟，服务端那条 verification 却是 10 分钟。
+        // 在 provider 授权页多犹豫一会儿，Cookie 先过期、校验行还在，
+        // 回调就报 state_security_mismatch。两边对齐，过期与否只由校验行说了算。
+        state: { attributes: { maxAge: OAUTH_STATE_MAX_AGE_SECONDS } },
       },
     },
     plugins,

--- a/cloud/src/routes/mobileAuth.ts
+++ b/cloud/src/routes/mobileAuth.ts
@@ -1,6 +1,7 @@
 /**
  * Android Session 交接。
  *
+ * 登录：
  *   App -> GET /api/v1/auth/mobile/start/:provider（Custom Tab，state Cookie 与回调同上下文）
  *       -> 系统浏览器 -> provider
  *       -> Better Auth callback（浏览器拿到 Cookie）
@@ -10,14 +11,24 @@
  *       -> App POST /api/v1/auth/mobile/exchange
  *       -> verifyOneTimeToken -> 返回 session.token -> 存进 Keystore
  *
+ * 绑定（已登录再挂一个第三方身份）：
+ *   App -> POST /api/v1/auth/mobile/link/:provider（WebView，bearer 认证）
+ *       -> generateOneTimeToken(当前 Session) -> 返回启动 URL
+ *       -> Custom Tab GET /api/v1/auth/mobile/link/:provider?ott=<一次性 token>
+ *       -> verifyOneTimeToken -> 以 bearer 调 link-social -> state Cookie 落在 Custom Tab
+ *       -> 系统浏览器 -> provider -> Better Auth callback（同一浏览器，state 对得上）
+ *       -> 302 newsnook://auth/callback?linked=<provider> -> App 刷新 /api/v1/me
+ *
  * 重点：长期 Session token 绝不出现在深链 URL 里，一次性 token 短时有效且用后即焚；
  * 回跳目标是写死的 `newsnook://auth/callback`，不接受任何客户端指定的跳转地址。
  *
- * 勿在 WebView 里 fetch sign-in/social 再开 Custom Tab：OAuth state Cookie 落在 WebView，
- * 回调在 Chrome Custom Tab，会 state_mismatch 并落到 `/?error=state_mismatch`（根路径 404）。
+ * 勿在 WebView 里 fetch sign-in/social 或 link-social 再开 Custom Tab：OAuth state Cookie
+ * 落在 WebView（Android 上请求还是 `credentials: 'omit'`，压根不会存），回调却在 Chrome
+ * Custom Tab，必然 state_mismatch 并落到 `/?error=state_mismatch`（根路径 400）。
+ * 两条流程都必须由 Custom Tab 自己发起，Session 靠一次性 token 交接。
  */
 
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+import type { FastifyInstance, FastifyReply } from 'fastify'
 
 import {
   MOBILE_AUTH_CALLBACK_URL,
@@ -26,7 +37,11 @@ import {
 } from '@newsnook/contracts'
 
 import type { NewsNookAuth } from '../auth.js'
-import { listEnabledSocialOAuthProviders, type CloudConfig } from '../config.js'
+import {
+  listEnabledSocialOAuthProviders,
+  type CloudConfig,
+  type SocialOAuthProviderId,
+} from '../config.js'
 import { ApiError, authRequired, validationFailed } from '../errors.js'
 import { toWebHeaders } from '../plugins/authSession.js'
 
@@ -38,8 +53,27 @@ export interface MobileAuthRouteOptions {
 
 const MOBILE_RATE_LIMIT = { max: 30, timeWindow: '1 minute' }
 
+function trimUrl(betterAuthUrl: string): string {
+  return betterAuthUrl.replace(/\/$/, '')
+}
+
 function mobileCompleteCallbackUrl(betterAuthUrl: string): string {
-  return `${betterAuthUrl.replace(/\/$/, '')}/api/v1/auth/mobile/complete`
+  return `${trimUrl(betterAuthUrl)}/api/v1/auth/mobile/complete`
+}
+
+/** 绑定成功后的固定回跳；App 据此刷新已绑定列表，不需要新的 Session */
+function mobileLinkedCallbackUrl(provider: string): string {
+  const target = new URL(MOBILE_AUTH_CALLBACK_URL)
+  target.searchParams.set('linked', provider)
+  return target.toString()
+}
+
+function assertEnabledProvider(config: CloudConfig, provider: string): SocialOAuthProviderId {
+  const enabled = new Set(listEnabledSocialOAuthProviders(config))
+  if (!enabled.has(provider as SocialOAuthProviderId)) {
+    throw validationFailed('Unsupported social provider')
+  }
+  return provider as SocialOAuthProviderId
 }
 
 function forwardSetCookies(response: Response, reply: FastifyReply): void {
@@ -47,22 +81,45 @@ function forwardSetCookies(response: Response, reply: FastifyReply): void {
   for (const cookie of setCookies) reply.header('set-cookie', cookie)
 }
 
-async function redirectSocialOAuth(
-  auth: NewsNookAuth,
-  betterAuthUrl: string,
-  authPath: '/api/auth/sign-in/social' | '/api/auth/link-social',
-  provider: string,
-  request: FastifyRequest,
-  reply: FastifyReply,
-): Promise<void> {
-  const callbackURL = mobileCompleteCallbackUrl(betterAuthUrl)
-  const webRequest = new Request(`${betterAuthUrl}${authPath}`, {
+/** Custom Tab 里出错时给人看的页面：这里没有 App 壳，JSON 只会显示成乱码 */
+function browserNotice(reply: FastifyReply, status: number, detail: string): FastifyReply {
+  return reply
+    .code(status)
+    .type('text/html; charset=utf-8')
+    .send(`<h1>登录未完成</h1><p>${detail}</p>`)
+}
+
+interface StartOAuthOptions {
+  auth: NewsNookAuth
+  betterAuthUrl: string
+  authPath: '/api/auth/sign-in/social' | '/api/auth/link-social'
+  provider: string
+  callbackURL: string
+  errorCallbackURL?: string
+  /** 绑定流程必须带：link-social 需要已登录的调用者，浏览器里没有 Cookie 只能走 bearer */
+  sessionToken?: string
+  reply: FastifyReply
+}
+
+/**
+ * 在**当前浏览器上下文**发起 OAuth：把 Better Auth 写的 state Cookie 原样转给调用方，
+ * 再 302 到 provider。调用方必须是最终要接住回调的那个浏览器。
+ */
+async function startOAuthInBrowser(options: StartOAuthOptions): Promise<void> {
+  const { auth, betterAuthUrl, authPath, provider, reply } = options
+
+  const headers: Record<string, string> = { 'content-type': 'application/json' }
+  if (options.sessionToken) headers.authorization = `Bearer ${options.sessionToken}`
+
+  const webRequest = new Request(`${trimUrl(betterAuthUrl)}${authPath}`, {
     method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      ...toWebHeaders(request),
-    },
-    body: JSON.stringify({ provider, callbackURL, disableRedirect: true }),
+    headers,
+    body: JSON.stringify({
+      provider,
+      callbackURL: options.callbackURL,
+      errorCallbackURL: options.errorCallbackURL,
+      disableRedirect: true,
+    }),
   })
 
   const response = await auth.handler(webRequest)
@@ -118,19 +175,86 @@ export async function registerMobileAuthRoutes(
     '/api/v1/auth/mobile/start/:provider',
     { config: { rateLimit: MOBILE_RATE_LIMIT } },
     async (request, reply) => {
-      const provider = (request.params as { provider: string }).provider
-      const enabled = new Set(listEnabledSocialOAuthProviders(options.config))
-      if (!enabled.has(provider as 'google' | 'github' | 'linuxdo')) {
-        throw validationFailed('Unsupported social provider')
-      }
-      return redirectSocialOAuth(
-        options.auth,
-        options.betterAuthUrl,
-        '/api/auth/sign-in/social',
-        provider,
-        request,
-        reply,
+      const provider = assertEnabledProvider(
+        options.config,
+        (request.params as { provider: string }).provider,
       )
+      return startOAuthInBrowser({
+        auth: options.auth,
+        betterAuthUrl: options.betterAuthUrl,
+        authPath: '/api/auth/sign-in/social',
+        provider,
+        callbackURL: mobileCompleteCallbackUrl(options.betterAuthUrl),
+        reply,
+      })
+    },
+  )
+
+  /**
+   * 绑定第一步（App WebView，bearer 认证）：只换一个一次性 token，
+   * 真正的 OAuth 启动留给 Custom Tab，state Cookie 才会落对地方。
+   */
+  app.post(
+    '/api/v1/auth/mobile/link/:provider',
+    { config: { rateLimit: MOBILE_RATE_LIMIT } },
+    async (request): Promise<{ url: string }> => {
+      const provider = assertEnabledProvider(
+        options.config,
+        (request.params as { provider: string }).provider,
+      )
+      await app.requireSession(request)
+
+      const generated = (await options.auth.api.generateOneTimeToken({
+        headers: toWebHeaders(request),
+      })) as { token: string } | null
+
+      if (!generated?.token) throw new ApiError('INTERNAL_ERROR', 'Failed to issue handoff token')
+
+      const url = new URL(`${trimUrl(options.betterAuthUrl)}/api/v1/auth/mobile/link/${provider}`)
+      url.searchParams.set('ott', generated.token)
+      return { url: url.toString() }
+    },
+  )
+
+  /** 绑定第二步（Custom Tab）：一次性 token 换出 Session，再在这个浏览器里发起 OAuth */
+  app.get(
+    '/api/v1/auth/mobile/link/:provider',
+    { config: { rateLimit: MOBILE_RATE_LIMIT } },
+    async (request, reply) => {
+      const provider = assertEnabledProvider(
+        options.config,
+        (request.params as { provider: string }).provider,
+      )
+      const ott = (request.query as { ott?: string }).ott
+      if (!ott) {
+        return browserNotice(reply, 400, '请回到「有所闻」重新发起绑定。')
+      }
+
+      let verified: VerifiedOneTimeToken | null = null
+      try {
+        verified = (await options.auth.api.verifyOneTimeToken({
+          body: { token: ott },
+        })) as VerifiedOneTimeToken | null
+      } catch {
+        // 过期 / 已用过 / 伪造：一律当作未认证，不泄漏具体原因
+        verified = null
+      }
+
+      if (!verified?.session?.token) {
+        return browserNotice(reply, 401, '绑定链接已失效，请回到「有所闻」重新发起绑定。')
+      }
+
+      return startOAuthInBrowser({
+        auth: options.auth,
+        betterAuthUrl: options.betterAuthUrl,
+        authPath: '/api/auth/link-social',
+        provider,
+        callbackURL: mobileLinkedCallbackUrl(provider),
+        // 出错也要把人送回 App，否则用户停在 API 域名的错误页上
+        errorCallbackURL: MOBILE_AUTH_CALLBACK_URL,
+        sessionToken: verified.session.token,
+        reply,
+      })
     },
   )
 
@@ -141,10 +265,7 @@ export async function registerMobileAuthRoutes(
       const session = await app.readSession(request)
       if (!session) {
         // 浏览器没有有效 Cookie：不要 302 回 App，否则 App 会拿到一个无效 ott
-        return reply
-          .code(401)
-          .type('text/html; charset=utf-8')
-          .send('<h1>登录未完成</h1><p>请回到「有所闻」重新发起登录。</p>')
+        return browserNotice(reply, 401, '请回到「有所闻」重新发起登录。')
       }
 
       const generated = (await options.auth.api.generateOneTimeToken({

--- a/cloud/tests/auth.test.ts
+++ b/cloud/tests/auth.test.ts
@@ -184,7 +184,17 @@ describe('auth', { skip: skipWithoutDatabase }, () => {
         (response.headers.location as string).includes('github'),
       '应重定向到 GitHub 授权页',
     )
-    assert.ok(response.headers['set-cookie'], '应在 Custom Tab 上下文写入 OAuth state Cookie')
+    const cookies = response.headers['set-cookie'] as string | string[] | undefined
+    assert.ok(cookies, '应在 Custom Tab 上下文写入 OAuth state Cookie')
+    const stateCookie = (Array.isArray(cookies) ? cookies : [cookies]).find((entry) =>
+      entry.split('=')[0]?.endsWith('.state'),
+    )
+    assert.ok(stateCookie)
+    assert.match(
+      stateCookie,
+      /Max-Age=600/i,
+      'state Cookie 与服务端校验行同为 10 分钟：在授权页多停留一会儿不该变成 state_mismatch',
+    )
 
     await githubCloud.close()
   })

--- a/cloud/tests/auth.test.ts
+++ b/cloud/tests/auth.test.ts
@@ -189,6 +189,106 @@ describe('auth', { skip: skipWithoutDatabase }, () => {
     await githubCloud.close()
   })
 
+  it('rejects the OAuth callback when link-social was started outside the browser', async () => {
+    // 复现线上故障：App 在 WebView 里 fetch link-social，state Cookie 落在 WebView，
+    // 回调却发生在 Custom Tab —— 校验行还在库里，Cookie 却对不上。
+    const githubCloud = await startTestCloud({
+      github: { clientId: 'gh-test-id', clientSecret: 'gh-test-secret' },
+    })
+    const user = await createSignedInUser(githubCloud, 'link-webview')
+
+    const started = await githubCloud.app.inject({
+      method: 'POST',
+      url: '/api/auth/link-social',
+      payload: { provider: 'github', callbackURL: 'http://127.0.0.1:5173/', disableRedirect: true },
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${user.bearerToken}` },
+    })
+    assert.equal(started.statusCode, 200)
+    const state = new URL(started.json().url).searchParams.get('state') ?? ''
+    assert.ok(state.length > 8)
+
+    const callback = await githubCloud.app.inject({
+      method: 'GET',
+      url: `/api/auth/callback/github?code=fake-code&state=${encodeURIComponent(state)}`,
+    })
+    assert.equal(callback.statusCode, 302)
+    assert.match(callback.headers.location as string, /error=state_mismatch/)
+
+    await githubCloud.close()
+  })
+
+  it('hands the link flow to the browser so the state cookie matches the callback', async () => {
+    const githubCloud = await startTestCloud({
+      github: { clientId: 'gh-test-id', clientSecret: 'gh-test-secret' },
+    })
+    const user = await createSignedInUser(githubCloud, 'link-mobile')
+
+    const anonymous = await githubCloud.app.inject({
+      method: 'POST',
+      url: '/api/v1/auth/mobile/link/github',
+    })
+    assert.equal(anonymous.statusCode, 401, '未登录不能发起绑定')
+
+    const unsupported = await githubCloud.app.inject({
+      method: 'POST',
+      url: '/api/v1/auth/mobile/link/google',
+      headers: { authorization: `Bearer ${user.bearerToken}` },
+    })
+    assert.ok(unsupported.statusCode >= 400, '未启用的 provider 不接受')
+
+    const started = await githubCloud.app.inject({
+      method: 'POST',
+      url: '/api/v1/auth/mobile/link/github',
+      headers: { authorization: `Bearer ${user.bearerToken}` },
+    })
+    assert.equal(started.statusCode, 200)
+
+    const startUrl = new URL(started.json().url)
+    assert.equal(startUrl.pathname, '/api/v1/auth/mobile/link/github')
+    const ott = startUrl.searchParams.get('ott') ?? ''
+    assert.ok(ott.length > 8)
+    assert.ok(
+      !started.body.includes(user.bearerToken ?? 'never'),
+      '交给浏览器的只有一次性 token，没有长期 Session',
+    )
+
+    const redirect = await githubCloud.app.inject({
+      method: 'GET',
+      url: `${startUrl.pathname}${startUrl.search}`,
+    })
+    assert.equal(redirect.statusCode, 302)
+    const authorizeUrl = new URL(redirect.headers.location as string)
+    assert.match(authorizeUrl.host, /github/)
+    const state = authorizeUrl.searchParams.get('state') ?? ''
+    assert.ok(state.length > 8)
+
+    const cookies = redirect.headers['set-cookie'] as string | string[] | undefined
+    const stateCookie = (Array.isArray(cookies) ? cookies : [cookies ?? '']).find((entry) =>
+      entry.split('=')[0]?.endsWith('.state'),
+    )
+    assert.ok(stateCookie, 'state Cookie 必须写在真正会接住回调的浏览器上')
+    const signed = decodeURIComponent(stateCookie.split(';')[0]?.split('=')[1] ?? '')
+    assert.ok(
+      signed.startsWith(`${state}.`),
+      'Cookie 里的 state 与授权 URL 上的 state 一致，回调才不会 state_mismatch',
+    )
+
+    const replay = await githubCloud.app.inject({
+      method: 'GET',
+      url: `${startUrl.pathname}${startUrl.search}`,
+    })
+    assert.equal(replay.statusCode, 401, '一次性 token 用后即焚')
+    assert.match(replay.body, /绑定链接已失效/)
+
+    const missing = await githubCloud.app.inject({
+      method: 'GET',
+      url: '/api/v1/auth/mobile/link/github',
+    })
+    assert.equal(missing.statusCode, 400)
+
+    await githubCloud.close()
+  })
+
   it('shows a friendly page when OAuth fails and lands on /?error=', async () => {
     const response = await cloud.app.inject({
       method: 'GET',

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -482,7 +482,11 @@ Outbox 落盘前 Secret 载荷会被抹成 null，真正的值在 push 前一刻
 **会话与 Secret**：Web 用 HttpOnly Cookie Session；Android 用 Keystore-backed SecureStore
 （`SecureStorePlugin.java`，AES/GCM，密钥不出 Keystore），长期 Session 与同步下来的 Secret 明文只存这里，
 不落普通 Preferences/localStorage。Android 社交登录走系统浏览器 → 一次性令牌深链 → 换 Session，
-长期 token 绝不出现在深链里。业务 API 从 Session 推导 `userId`，从不信任客户端 payload 内的用户 id。
+长期 token 绝不出现在深链里。绑定第三方身份同理：App 先在 WebView 里换一枚一次性令牌，
+再由 Custom Tab 打开 `/api/v1/auth/mobile/link/:provider?ott=…` 发起 OAuth——
+OAuth state Cookie 必须写在真正接住回调的那个浏览器上，否则回调只会 `state_mismatch`；
+绑定完成后回跳 `newsnook://auth/callback?linked=<provider>`，会话不变，App 只刷新已绑定列表。
+业务 API 从 Session 推导 `userId`，从不信任客户端 payload 内的用户 id。
 Secret 上传但不做 E2EE；服务端 AES-256-GCM 加密（AAD 绑定 `userId:secretKey`），日志与推送摘要禁止明文。
 
 **服务端**：同一用户的并发 push 由 `sync_heads` 那一行的 `SELECT ... FOR UPDATE` 事务行锁串行化，

--- a/docs/cloud-deploy.md
+++ b/docs/cloud-deploy.md
@@ -223,6 +223,13 @@ DATABASE_URL=postgres://.../newsnook_restore npm run cloud:migrate
   App 用它换 Session token 并存进 Android Keystore（见 `cloud/src/routes/mobileAuth.ts`）。
 - 同邮箱的不同登录方式**不会被自动合并**（`disableImplicitLinking: true`）；
   绑定必须由已登录用户在「账户与同步」里显式发起。
+- Android 的登录与绑定都必须由 Custom Tab 自己向服务端发起
+  （`GET /api/v1/auth/mobile/start/:provider`、`GET /api/v1/auth/mobile/link/:provider?ott=…`）。
+  在 WebView 里 fetch `sign-in/social` 或 `link-social` 再把授权 URL 丢给浏览器，
+  OAuth state Cookie 会留在 WebView，回调必然 `state_mismatch`。
+  绑定流程的 Session 靠一次性令牌交接，回跳固定是 `newsnook://auth/callback?linked=<provider>`。
+- 这些路由不需要新的环境变量：`BETTER_AUTH_URL` 仍须与真实回调域名（反代对外的 host）
+  完全一致，反代前置时保持 `TRUST_PROXY=true` 并转发 `X-Forwarded-Proto` / `X-Forwarded-Host`。
 
 ## 9. CI
 

--- a/docs/cloud-deploy.md
+++ b/docs/cloud-deploy.md
@@ -230,6 +230,12 @@ DATABASE_URL=postgres://.../newsnook_restore npm run cloud:migrate
   绑定流程的 Session 靠一次性令牌交接，回跳固定是 `newsnook://auth/callback?linked=<provider>`。
 - 这些路由不需要新的环境变量：`BETTER_AUTH_URL` 仍须与真实回调域名（反代对外的 host）
   完全一致，反代前置时保持 `TRUST_PROXY=true` 并转发 `X-Forwarded-Proto` / `X-Forwarded-Host`。
+- Web 端的 `CLIENT_ORIGINS` 域名应与 `BETTER_AUTH_URL` 同一个注册域
+  （如 `news.example.com` 与 `api-news.example.com`）。跨注册域部署时，
+  浏览器会把 `link-social` / `sign-in/social` 响应里的 `SameSite=Lax` state Cookie
+  当第三方 Cookie 拦掉，回调同样报 `state_mismatch`。
+- state Cookie 的存活时间与服务端校验行对齐到 10 分钟
+  （`OAUTH_STATE_MAX_AGE_SECONDS`）；在 provider 授权页停留过久不再变成 `state_mismatch`。
 
 ## 9. CI
 

--- a/scripts/account-auth.test.ts
+++ b/scripts/account-auth.test.ts
@@ -7,7 +7,11 @@ import assert from 'node:assert/strict'
 
 import { shareTokenFromAppUrl } from '../src/lib/appDeepLink'
 import { createAccountAdapter } from '../src/features/account/authClient'
-import { isAuthCallbackUrl, oneTimeTokenFromAppUrl } from '../src/features/account/mobileCallback'
+import {
+  authCallbackFromAppUrl,
+  isAuthCallbackUrl,
+  oneTimeTokenFromAppUrl,
+} from '../src/features/account/mobileCallback'
 import {
   SECURE_KEYS,
   createMemorySecureStore,
@@ -109,6 +113,18 @@ assert.equal(
 
 assert.ok(isAuthCallbackUrl('newsnook://auth/callback?ott=x'))
 assert.ok(!isAuthCallbackUrl('newsnook://a/token'))
+
+assert.deepEqual(
+  authCallbackFromAppUrl('newsnook://auth/callback?linked=github'),
+  { ott: null, linked: 'github', error: null },
+  '绑定回流带 provider，不带一次性 token',
+)
+assert.deepEqual(
+  authCallbackFromAppUrl('newsnook://auth/callback?error=state_mismatch'),
+  { ott: null, linked: null, error: 'state_mismatch' },
+  '失败回流带错误码',
+)
+assert.equal(authCallbackFromAppUrl('newsnook://a/share-token'), null, '分享深链不是认证回流')
 assert.equal(
   shareTokenFromAppUrl('newsnook://auth/callback?ott=abc123'),
   null,
@@ -302,6 +318,9 @@ assert.equal(
   const { fetchImpl, requests } = createFetchStub({
     '/api/auth/sign-in/social': { body: { url: 'https://github.test/login/oauth' } },
     '/api/auth/link-social': { body: { url: 'https://github.test/login/oauth/link' } },
+    '/api/v1/auth/mobile/link/github': {
+      body: { url: `${BASE_URL}/api/v1/auth/mobile/link/github?ott=handoff` },
+    },
   })
   const opened: string[] = []
   const adapter = createAccountAdapter({
@@ -323,7 +342,59 @@ assert.equal(
   assert.equal(requests.length, 0, '不再经 WebView fetch sign-in/social')
 
   assert.equal(await adapter.linkSocial('github'), 'external')
-  assert.equal(opened[1], 'https://github.test/login/oauth/link', '绑定走 link-social，不是重新登录')
+  assert.equal(
+    opened[1],
+    `${BASE_URL}/api/v1/auth/mobile/link/github?ott=handoff`,
+    '绑定同样由 Custom Tab 发起，state Cookie 不会落在 WebView 里',
+  )
+  assert.ok(
+    !requests.some((request) => request.url.endsWith('/api/auth/link-social')),
+    'WebView 不再直接 fetch link-social：那样拿到的 state Cookie 回调时用不上',
+  )
+  assert.equal(requests[0]!.url, `${BASE_URL}/api/v1/auth/mobile/link/github`)
+  assert.equal(requests[0]!.method, 'POST')
+  assert.equal(requests[0]!.credentials, 'omit', 'Android 靠 bearer，不指望 WebView Cookie')
+}
+
+// --- Android 绑定回流：刷新已绑定列表，不换会话 -------------------------------
+
+{
+  const { fetchImpl, requests } = createFetchStub({
+    '/api/v1/me': {
+      body: {
+        user: { id: 'user-1', email: 'reader@example.test', name: null, emailVerified: true, image: null },
+        linkedProviders: ['credential', 'github'],
+        device: null,
+      },
+    },
+  })
+  const store = createMemorySecureStore()
+  await writeStoredSession(store, { token: 'kept-token', userId: 'user-1', expiresAt: 0 })
+
+  const adapter = createAccountAdapter({
+    platform: 'android',
+    baseUrl: BASE_URL,
+    secureStore: store,
+    fetchImpl,
+    openExternal: () => {},
+  })
+
+  const session = await adapter.handleAuthDeepLink('newsnook://auth/callback?linked=github')
+  assert.deepEqual(session?.linkedProviders, ['credential', 'github'])
+  assert.equal((await readStoredSession(store))?.token, 'kept-token', '绑定不动本机长期凭证')
+  assert.ok(
+    !requests.some((request) => request.url.includes('/mobile/exchange')),
+    '绑定回流不换会话，不该走一次性 token 交换',
+  )
+
+  await assert.rejects(
+    () => adapter.handleAuthDeepLink('newsnook://auth/callback?error=state_mismatch'),
+    (error: unknown) => {
+      assert.ok(error instanceof AccountError)
+      assert.equal(error.code, 'OAUTH_CALLBACK_FAILED')
+      return true
+    },
+  )
 }
 
 {

--- a/src/features/account/authClient.ts
+++ b/src/features/account/authClient.ts
@@ -18,7 +18,7 @@ import type { MeResponse, MobileExchangeResponse, AuthConfigResponse } from '@ne
 import { log } from '../../lib/logger'
 import type { CloudFetch, CloudRequestInit } from '../sync/transport'
 import { resolveCloudBaseUrl } from './config'
-import { oneTimeTokenFromAppUrl } from './mobileCallback'
+import { authCallbackFromAppUrl } from './mobileCallback'
 import {
   clearStoredSession,
   getSecureStore,
@@ -269,18 +269,41 @@ export function createAccountAdapter(options: AccountAdapterOptions): AccountAda
     },
 
     async linkSocial(provider: SocialProvider): Promise<SocialSignInMode> {
-      // 已登录绑定仍走 WebView fetch；Android 上 bearer 与 state Cookie 上下文仍可能分裂
+      if (native) {
+        // 与登录同理：state Cookie 必须写在 Custom Tab 上，WebView 里 fetch 出来的必然对不上。
+        // 服务端换一枚一次性 token，真正的 link-social 由 Custom Tab 自己发起。
+        const { data } = await callAuth<{ url?: string }>(
+          `/api/v1/auth/mobile/link/${provider}`,
+          {},
+        )
+        if (!data.url) throw new AccountError('OAUTH_URL_MISSING', '无法开始绑定，请稍后再试')
+        await options.openExternal(data.url)
+        return 'external'
+      }
       const url = await socialUrl('/api/auth/link-social', provider)
       await options.openExternal(url)
-      return native ? 'external' : 'redirect'
+      return 'redirect'
     },
 
     async handleAuthDeepLink(url: string): Promise<AccountSession | null> {
-      const ott = oneTimeTokenFromAppUrl(url)
-      if (!ott) return null
+      const params = authCallbackFromAppUrl(url)
+      if (!params) return null
+
+      if (params.error) {
+        log.account.warn('oauth callback failed', { code: params.error })
+        throw new AccountError('OAUTH_CALLBACK_FAILED', '第三方账号授权没能完成，请重试')
+      }
+
+      if (params.linked) {
+        // 绑定不换会话，本机 bearer 照旧；只要把已绑定列表刷新回来
+        log.account.info('linked social account', { provider: params.linked })
+        return fetchMe()
+      }
+
+      if (!params.ott) return null
 
       const { data } = await callAuth<MobileExchangeResponse>('/api/v1/auth/mobile/exchange', {
-        token: ott,
+        token: params.ott,
       })
       if (!data?.sessionToken) throw new AccountError('SESSION_MISSING', '登录回流失败，请重新登录')
 

--- a/src/features/account/mobileCallback.ts
+++ b/src/features/account/mobileCallback.ts
@@ -1,5 +1,8 @@
 /**
- * Android 认证回流深链：`newsnook://auth/callback?ott=<一次性 token>`。
+ * Android 认证回流深链：
+ * - 登录：`newsnook://auth/callback?ott=<一次性 token>`
+ * - 绑定：`newsnook://auth/callback?linked=<provider>`（绑定不换会话，只要刷新已绑定列表）
+ * - 失败：`newsnook://auth/callback?error=<Better Auth 错误码>`
  *
  * 与分享深链 `newsnook://a/<token>` 共用同一个 scheme，所以这里必须严格匹配
  * `auth/callback` 这一条路径，绝不能把分享 token 当成认证 token（反之亦然）。
@@ -11,6 +14,15 @@ import { MOBILE_AUTH_CALLBACK_URL } from '@newsnook/contracts/protocol'
 
 const CALLBACK_PREFIX = MOBILE_AUTH_CALLBACK_URL.toLowerCase()
 
+export interface AuthCallbackParams {
+  /** 登录回流的一次性 token */
+  ott: string | null
+  /** 绑定成功回流的 provider id */
+  linked: string | null
+  /** Better Auth 回传的错误码，如 `state_mismatch` */
+  error: string | null
+}
+
 function decodeComponent(value: string): string {
   try {
     return decodeURIComponent(value.replace(/\+/g, ' '))
@@ -19,8 +31,8 @@ function decodeComponent(value: string): string {
   }
 }
 
-/** 只认认证回调深链；分享链接、其他 host、缺少 ott 一律返回 null */
-export function oneTimeTokenFromAppUrl(url: string): string | null {
+/** 认证回调深链的查询串；分享链接、其他 host、前缀相同但路径不同一律返回 null */
+function callbackQuery(url: string): string | null {
   const trimmed = url.trim()
   if (!trimmed) return null
 
@@ -31,17 +43,34 @@ export function oneTimeTokenFromAppUrl(url: string): string | null {
   // 前缀之后只允许直接跟查询串/锚点/结尾斜杠，`newsnook://auth/callbackfoo` 不算
   if (rest && !/^[/?#]/.test(rest)) return null
 
-  const query = rest.split('#')[0]?.split('?')[1] ?? ''
-  if (!query) return null
+  return rest.split('#')[0]?.split('?')[1] ?? ''
+}
 
+function readParam(query: string, name: string): string | null {
   for (const part of query.split('&')) {
     const separator = part.indexOf('=')
     if (separator < 0) continue
-    if (part.slice(0, separator) !== 'ott') continue
-    const token = decodeComponent(part.slice(separator + 1)).trim()
-    return token || null
+    if (part.slice(0, separator) !== name) continue
+    const value = decodeComponent(part.slice(separator + 1)).trim()
+    return value || null
   }
   return null
+}
+
+/** 认证回调深链的参数；不是认证深链返回 null */
+export function authCallbackFromAppUrl(url: string): AuthCallbackParams | null {
+  const query = callbackQuery(url)
+  if (query === null) return null
+  return {
+    ott: readParam(query, 'ott'),
+    linked: readParam(query, 'linked'),
+    error: readParam(query, 'error'),
+  }
+}
+
+/** 只认认证回调深链；分享链接、其他 host、缺少 ott 一律返回 null */
+export function oneTimeTokenFromAppUrl(url: string): string | null {
+  return authCallbackFromAppUrl(url)?.ott ?? null
 }
 
 /** 是否是认证深链（哪怕缺少 ott）：用于和分享深链分流，避免互相误处理 */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

生产环境 GitHub 绑定账号失败：

```
POST /api/auth/link-social → 200
GET /api/auth/callback/github → state_security_mismatch
GET /?error=state_mismatch → 400
```

## 根因

Better Auth OAuth state 校验要求：**写入 state Cookie 的浏览器** 与 **接住 GitHub 回调的浏览器** 必须是同一个。

Android 绑定流程原先在 WebView 里 `fetch /api/auth/link-social`（`credentials: omit` + Bearer，Cookie 不落盘），再用 Custom Tab 打开授权 URL —— 回调落在 Custom Tab，没有 state Cookie，触发 `State mismatch: State not persisted correctly`。

登录流程已有 `/api/v1/auth/mobile/start/:provider` 规避此问题，绑定流程未对齐。

次要因素：state Cookie `Max-Age=300` 与 verification 行 `expiresAt=600s` 不一致，用户在 GitHub 页停留 >5 分钟也会报同样错误。

## 修复

1. **Android 绑定改走 Custom Tab 交接**（与登录同模式）：
   - `POST /api/v1/auth/mobile/link/:provider`（bearer）换一次性 token
   - Custom Tab 打开 `GET /api/v1/auth/mobile/link/:provider?ott=…`，在此浏览器上下文调 `link-social` 写 state Cookie，再 302 到 GitHub
   - 成功回跳 `newsnook://auth/callback?linked=<provider>`，失败 `?error=…`

2. **state Cookie maxAge 对齐到 600s**

3. **重构** `redirectSocialOAuth` → `startOAuthInBrowser`，修正 Headers 展开空对象问题

4. 补充集成测试与文档

## 部署

- 无需新增环境变量
- 客户端与服务端需**同步发版**（老 App + 新服务端仍走旧路径会失败）
- 确认 `BETTER_AUTH_URL=https://api-news.aizeek.com`、`TRUST_PROXY=true`

## 验证

- `test:cloud-auth` ✅
- `test:account-auth` ✅
- `test:cloud` 82/82 ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e9de55a-3bac-4f0d-a28e-36babbebfb2f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e9de55a-3bac-4f0d-a28e-36babbebfb2f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

