### PR TITLE
fix(scroll): 修复看图/看视频后上下滑动偶发失效

### DIFF
--- a/scripts/gesture-styles.test.ts
+++ b/scripts/gesture-styles.test.ts
@@ -1,19 +1,77 @@
 import assert from 'node:assert/strict'
 import { parseHTML } from 'linkedom'
-import { clearGestureCompositorStyles } from '../src/lib/gestureStyles'
 
-const { document } = parseHTML('<div id="surface"></div>')
+import {
+  bodyScrollLockDepth,
+  lockBodyScroll,
+  resetBodyScrollLock,
+} from '../src/lib/bodyScrollLock'
+import {
+  clearGestureCompositorStyles,
+  recoverAppScrollAfterNavigation,
+  recoverAppScrollSurfaces,
+  SCROLL_SURFACE_ATTR,
+} from '../src/lib/gestureStyles'
+
+const { document } = parseHTML('<body><div id="surface"></div></body>')
+;(globalThis as typeof globalThis & { document: Document }).document = document as unknown as Document
 const surface = document.querySelector<HTMLElement>('#surface')
 assert.ok(surface)
 
 surface.style.transform = 'translate3d(0, 0, 0)'
 surface.style.transition = 'transform 220ms ease'
 surface.style.willChange = 'transform'
+surface.dataset.swipeBackActive = 'true'
 
 clearGestureCompositorStyles(surface)
 
 assert.equal(surface.style.transform, '')
 assert.equal(surface.style.transition, '')
 assert.equal(surface.style.willChange, '')
+assert.equal(surface.dataset.swipeBackActive, undefined)
+
+resetBodyScrollLock()
+document.body.style.overflow = 'auto'
+
+const releaseA = lockBodyScroll()
+assert.equal(document.body.style.overflow, 'hidden')
+assert.equal(bodyScrollLockDepth(), 1)
+
+const releaseB = lockBodyScroll()
+assert.equal(bodyScrollLockDepth(), 2)
+
+releaseA()
+assert.equal(document.body.style.overflow, 'hidden')
+assert.equal(bodyScrollLockDepth(), 1)
+
+releaseB()
+assert.equal(document.body.style.overflow, 'auto')
+assert.equal(bodyScrollLockDepth(), 0)
+
+// Out-of-order release must not leave overflow stuck on hidden.
+const releaseC = lockBodyScroll()
+const releaseD = lockBodyScroll()
+releaseC()
+releaseD()
+assert.equal(document.body.style.overflow, 'auto')
+
+const feed = document.createElement('div')
+feed.setAttribute(SCROLL_SURFACE_ATTR, '')
+feed.style.transform = 'translate3d(0, 12px, 0)'
+document.body.appendChild(feed)
+document.documentElement.classList.add('is-video-fullscreen')
+document.body.style.overflow = 'hidden'
+lockBodyScroll()
+
+recoverAppScrollSurfaces()
+assert.equal(feed.style.transform, '')
+assert.equal(document.documentElement.classList.contains('is-video-fullscreen'), false)
+assert.equal(document.body.style.overflow, 'hidden')
+
+resetBodyScrollLock()
+assert.equal(document.body.style.overflow, '')
+
+recoverAppScrollAfterNavigation()
+assert.equal(document.body.style.overflow, '')
 
 console.log('gesture-styles: ok')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import {
   syncBodyPins,
 } from './lib/bodyCache'
 import { sortArticles } from './lib/feedPagination'
+import { recoverAppScrollAfterNavigation } from './lib/gestureStyles'
 import { log } from './lib/logger'
 import {
   buildReadingProfile,
@@ -492,6 +493,7 @@ export default function App() {
   const closeReader = useCallback(() => {
     setReading(null)
     clearShareLocation()
+    recoverAppScrollAfterNavigation()
   }, [])
 
   const dismissDeepLinkError = useCallback(() => {

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useId, useRef, useState, type ReactNode } from 'react'
 import { Check } from 'lucide-react'
 
+import { lockBodyScroll } from '../lib/bodyScrollLock'
+
 /** 弹窗次要操作：描边取消钮 */
 const DIALOG_CANCEL_CLASS =
   'rounded-full border border-haze bg-transparent px-4 py-1.5 font-mono text-[11px] text-paper-muted transition-colors hover:text-paper'
@@ -39,11 +41,10 @@ export function OptionPickerDialog<T extends string>({
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') onCancel()
     }
-    const previousOverflow = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
+    const unlock = lockBodyScroll()
     window.addEventListener('keydown', onKey)
     return () => {
-      document.body.style.overflow = previousOverflow
+      unlock()
       window.removeEventListener('keydown', onKey)
     }
   }, [open, onCancel])

--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -10,6 +10,8 @@ import {
 import { Download, Share2, X } from 'lucide-react'
 
 import { saveImageToGallery, shareImage } from '../lib/imageActions'
+import { lockBodyScroll } from '../lib/bodyScrollLock'
+import { recoverAppScrollSurfaces } from '../lib/gestureStyles'
 
 interface Props {
   src: string
@@ -126,13 +128,27 @@ export function ImageLightbox({ src, alt = '', onClose, overlayCloserRef }: Prop
     [applyTransform, clampTranslation],
   )
 
-  useEffect(() => {
-    const previousOverflow = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
-    return () => {
-      document.body.style.overflow = previousOverflow
-    }
+  const releaseStageCaptures = useCallback(() => {
+    const stage = stageRef.current
+    if (!stage) return
+    pointersRef.current.forEach((_, pointerId) => {
+      if (stage.hasPointerCapture(pointerId)) stage.releasePointerCapture(pointerId)
+    })
+    pointersRef.current.clear()
+    pinchStartRef.current = null
+    panStartRef.current = null
+    closingSwipeRef.current.active = false
   }, [])
+
+  useEffect(() => {
+    const unlock = lockBodyScroll()
+    return () => {
+      clearLongPress()
+      releaseStageCaptures()
+      unlock()
+      recoverAppScrollSurfaces()
+    }
+  }, [clearLongPress, releaseStageCaptures])
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {

--- a/src/components/InkVideoPlayer.tsx
+++ b/src/components/InkVideoPlayer.tsx
@@ -24,6 +24,7 @@ import {
   needsMediaHotlinkBypass,
 } from '../lib/mediaFetch'
 import { setNativeFullScreen } from '../lib/nativeChrome'
+import { recoverAppScrollSurfaces } from '../lib/gestureStyles'
 import { getVideoStatusMessage } from '../lib/videoStatus'
 import {
   createBrightnessControl,
@@ -193,6 +194,7 @@ export function InkVideoPlayer({ src, poster, title, format, sourcePage, request
 function InkVideoPlayerReady({ src, poster, title, format, sourcePage, requestHeaders, extraUrls, resources, onSelectResource, onRefreshSource, onPlaybackError, fullscreenHandleRef }: Props & { onSelectResource?: (resource: MediaResourceDescriptor) => void }) {
   const rootRef = useRef<HTMLDivElement>(null)
   const stageRef = useRef<HTMLDivElement>(null)
+  const gestureSurfaceRef = useRef<HTMLDivElement>(null)
   const videoRef = useRef<HTMLVideoElement>(null)
   const hlsRef = useRef<Hls | null>(null)
   const dashRef = useRef<{ reset: () => void } | null>(null)
@@ -751,14 +753,32 @@ function InkVideoPlayerReady({ src, poster, title, format, sourcePage, requestHe
 
   useEffect(() => {
     if (!immersive) return
+    const root = rootRef.current
     // Entry/exit are awaited in toggleFullscreen so the Activity transition is
     // ordered. This cleanup only covers unmount/source replacement while fullscreen.
     return () => {
-      if (!Capacitor.isNativePlatform()) return
-      void setVideoFullscreen(false).then((applied) => {
-        if (!applied) void setNativeFullScreen(false)
-      })
+      void (async () => {
+        if (Capacitor.isNativePlatform()) {
+          const applied = await setVideoFullscreen(false)
+          if (!applied) await setNativeFullScreen(false)
+        } else {
+          if (root && document.fullscreenElement === root) {
+            try {
+              await document.exitFullscreen()
+            } catch {
+              // Keep current browser fullscreen state if exit is rejected.
+            }
+          }
+          await setNativeFullScreen(false)
+        }
+        recoverAppScrollSurfaces()
+      })()
     }
+  }, [immersive])
+
+  useEffect(() => {
+    if (immersive) return
+    recoverAppScrollSurfaces()
   }, [immersive])
 
   /** 进入全屏时对齐当前系统档位，退出时把亮度还给系统。 */
@@ -798,12 +818,19 @@ function InkVideoPlayerReady({ src, poster, title, format, sourcePage, requestHe
       if (longPressTimerRef.current != null) window.clearTimeout(longPressTimerRef.current)
       if (hudTimerRef.current != null) window.clearTimeout(hudTimerRef.current)
       if (toastTimerRef.current != null) window.clearTimeout(toastTimerRef.current)
+      const surface = gestureSurfaceRef.current
+      if (surface) {
+        activePointersRef.current.forEach((_, pointerId) => {
+          if (surface.hasPointerCapture(pointerId)) surface.releasePointerCapture(pointerId)
+        })
+      }
       activePointersRef.current.clear()
       pinchRef.current = null
       // 卸载时若仍在全屏，窗口亮度必须归还系统，否则整个应用会一直停在调暗状态
       brightnessControl.release()
       volumeControl.release()
       void releasePlayerScreenOrientation()
+      recoverAppScrollSurfaces()
     },
     [brightnessControl, releasePlayerScreenOrientation, volumeControl],
   )
@@ -1244,6 +1271,9 @@ function InkVideoPlayerReady({ src, poster, title, format, sourcePage, requestHe
   }
 
   const onGesturePointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
     const { point } = pointerLocation(event)
     activePointersRef.current.delete(event.pointerId)
     clearGestureTimers()
@@ -1315,7 +1345,10 @@ function InkVideoPlayerReady({ src, poster, title, format, sourcePage, requestHe
     }, DOUBLE_TAP_MS)
   }
 
-  const onGesturePointerCancel = () => {
+  const onGesturePointerCancel = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
     activePointersRef.current.clear()
     pinchRef.current = null
     multiTouchRef.current = false
@@ -1392,6 +1425,7 @@ function InkVideoPlayerReady({ src, poster, title, format, sourcePage, requestHe
 
         {ready && !fatal && (
           <div
+            ref={gestureSurfaceRef}
             data-video-gesture-surface=""
             className="absolute inset-0 z-[1] touch-none select-none"
             onPointerDown={onGesturePointerDown}

--- a/src/components/inkVideoPlayer/MediaResourceOverlay.tsx
+++ b/src/components/inkVideoPlayer/MediaResourceOverlay.tsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react'
 import { ListVideo } from 'lucide-react'
 
 import type { MediaResourceDescriptor } from '../../features/mediaSniffer/types'
+import { lockBodyScroll } from '../../lib/bodyScrollLock'
 
 export function MediaResourceOverlay({
   resources,
@@ -25,11 +26,10 @@ export function MediaResourceOverlay({
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') onToggle()
     }
-    const previousOverflow = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
+    const unlock = lockBodyScroll()
     window.addEventListener('keydown', onKey)
     return () => {
-      document.body.style.overflow = previousOverflow
+      unlock()
       window.removeEventListener('keydown', onKey)
     }
   }, [open, onToggle])

--- a/src/features/sync/ConflictResolutionSheet.tsx
+++ b/src/features/sync/ConflictResolutionSheet.tsx
@@ -31,6 +31,7 @@ import {
   type ConflictScope,
 } from './conflictView'
 import { describeSyncError } from './notifier'
+import { lockBodyScroll } from '../../lib/bodyScrollLock'
 
 const ENTITY_ICON: Record<SyncEntityType, typeof Rss> = {
   subscription: Rss,
@@ -91,11 +92,10 @@ export function ConflictResolutionSheet({ open, conflicts, onApply, onClose }: P
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape' && !applying) onClose()
     }
-    const previousOverflow = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
+    const unlock = lockBodyScroll()
     window.addEventListener('keydown', onKey)
     return () => {
-      document.body.style.overflow = previousOverflow
+      unlock()
       window.removeEventListener('keydown', onKey)
     }
   }, [open, applying, onClose])

--- a/src/lib/bodyScrollLock.ts
+++ b/src/lib/bodyScrollLock.ts
@@ -1,0 +1,38 @@
+/**
+ * Reference-counted body scroll lock for modal overlays.
+ *
+ * Multiple overlays may lock scroll at the same time (e.g. lightbox while a
+ * confirm sheet is open). Saving/restoring `document.body.style.overflow` per
+ * component breaks when they unmount out of order and can leave the page stuck
+ * with `overflow: hidden`.
+ */
+let lockCount = 0
+let savedOverflow = ''
+
+export function lockBodyScroll(): () => void {
+  if (lockCount === 0) {
+    savedOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+  }
+  lockCount += 1
+
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    lockCount = Math.max(0, lockCount - 1)
+    if (lockCount === 0) {
+      document.body.style.overflow = savedOverflow
+    }
+  }
+}
+
+/** For tests and emergency recovery after navigation. */
+export function resetBodyScrollLock(): void {
+  lockCount = 0
+  document.body.style.overflow = ''
+}
+
+export function bodyScrollLockDepth(): number {
+  return lockCount
+}

--- a/src/lib/gestureStyles.ts
+++ b/src/lib/gestureStyles.ts
@@ -1,3 +1,5 @@
+import { resetBodyScrollLock } from './bodyScrollLock'
+
 /**
  * 撤销手势识别阶段临时创建的合成层。
  *
@@ -8,4 +10,40 @@ export function clearGestureCompositorStyles(element: HTMLElement): void {
   element.style.transform = ''
   element.style.transition = ''
   element.style.willChange = ''
+  delete element.dataset.swipeBackActive
 }
+
+/** 标记可纵向滚动的表面，便于在导航/浮层关闭后统一恢复。 */
+export const SCROLL_SURFACE_ATTR = 'data-scroll-surface'
+
+/**
+ * 恢复单个滚动容器与其手势祖先上的合成层残留。
+ */
+export function recoverScrollSurface(element: HTMLElement | null | undefined): void {
+  if (!element) return
+  clearGestureCompositorStyles(element)
+  const shell = element.closest<HTMLElement>('.reader-swipe-surface')
+  if (shell && shell !== element) clearGestureCompositorStyles(shell)
+}
+
+/**
+ * 在离开图片/视频等强手势场景后唤醒页面滚动。
+ *
+ * 清理列表/阅读器上的 transform 合成层残留（Android WebView 触摸序列被打断后
+ * 的经典卡死）。关闭整页阅读器时请额外调用 `resetBodyScrollLock()`。
+ */
+export function recoverAppScrollSurfaces(): void {
+  document.documentElement.classList.remove('is-video-fullscreen')
+
+  document.querySelectorAll<HTMLElement>(`[${SCROLL_SURFACE_ATTR}]`).forEach((surface) => {
+    recoverScrollSurface(surface)
+  })
+}
+
+/** 阅读器/列表整页退出：同时复位 body overflow 锁计数。 */
+export function recoverAppScrollAfterNavigation(): void {
+  resetBodyScrollLock()
+  recoverAppScrollSurfaces()
+}
+
+export { resetBodyScrollLock }

--- a/src/screens/FeedScreen.tsx
+++ b/src/screens/FeedScreen.tsx
@@ -12,6 +12,7 @@ import { usePullToRefresh } from '../hooks/usePullToRefresh'
 import { useReducedMotion } from '../hooks/useReducedMotion'
 import { useSwipeCategory, type SwipeDirection } from '../hooks/useSwipeCategory'
 import { inkPulse, markRevealedAll, revealItems } from '../lib/motion'
+import { SCROLL_SURFACE_ATTR } from '../lib/gestureStyles'
 import type { PaginationViewState } from '../lib/feedPagination'
 import { chineseDate, dayBucket, relativeTime } from '../lib/time'
 import type { Article, RefreshProgress, SourceStatus } from '../lib/types'
@@ -794,6 +795,7 @@ export const FeedScreen = memo(function FeedScreen({
   const listScroller = (
     <div
       ref={containerRef}
+      {...{ [SCROLL_SURFACE_ATTR]: '' }}
       onScroll={onListScroll}
       className="scroll-hidden h-full overflow-x-hidden overflow-y-auto overscroll-contain bg-ink"
       style={{

--- a/src/screens/ReaderScreen.tsx
+++ b/src/screens/ReaderScreen.tsx
@@ -32,6 +32,7 @@ import { deferMediaInHtml, DEFERRED_SRC_ATTR, type DeferredHostPhase } from '../
 import { stageYoutubeEmbedsInHtml } from '../lib/youtubeEmbeds'
 import { shouldAutoLoadMedia } from '../lib/mediaLoadPolicy'
 import { revealReader } from '../lib/motion'
+import { SCROLL_SURFACE_ATTR } from '../lib/gestureStyles'
 import {
   flushReadingPositions,
   forgetReadingPosition,
@@ -1217,6 +1218,7 @@ export function ReaderScreen({
 
         <div
           ref={rootRef}
+          {...{ [SCROLL_SURFACE_ATTR]: '' }}
           onScroll={einkMode ? undefined : handleScroll}
           className={`scroll-hidden min-h-0 flex-1 overflow-x-hidden ${
             einkMode


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

用户在看图（灯箱）或播放文章内视频后，返回文章或列表时偶发无法上下滑动，只能退出重开 App。

## 根因

两类独立问题叠加：

1. **Body overflow 嵌套锁**：`ImageLightbox`、视频资源浮层、确认弹窗等各自 `save/restore document.body.style.overflow`。多个浮层嵌套或乱序卸载时，后关闭的浮层可能把 `overflow` 恢复成 `hidden`，导致页面永久锁滚。

2. **Android WebView 合成层残留**：下拉刷新、边缘返回、横滑分类等手势会在滚动容器上写入 `translate3d` 合成层。看图/看视频时触摸序列被中断（`touch-action: none`、pointer capture），离开后容器偶发留在失效合成层，纵滑失效。项目内 `gestureStyles.ts` 已有注释与局部清理，但未覆盖灯箱/视频退出与阅读器关闭路径。

## 修复

- 新增 `bodyScrollLock.ts`：引用计数式 body 滚动锁，替换各浮层独立 save/restore
- 扩展 `gestureStyles.ts`：`recoverAppScrollSurfaces` / `recoverAppScrollAfterNavigation` 统一清理合成层与 `is-video-fullscreen`
- `ImageLightbox`：卸载时释放 pointer capture 并恢复滚动
- `InkVideoPlayer`：退出全屏/卸载时释放 capture、清理原生全屏态并恢复滚动
- `App.closeReader`：关闭阅读器时调用 `recoverAppScrollAfterNavigation`
- 为 Feed 列表与 Reader 滚动容器标记 `data-scroll-surface`

## 验证

- `npm run test:gesture-styles` ✅
- `npm run lint` ✅（仅既有 warning）

## 风险

- `recoverAppScrollSurfaces` 在视频退出全屏时会清除 `is-video-fullscreen`；若未来支持多播放器同屏需再评估
- 真机复现路径隐蔽，建议在 Android 上回归：看图 → 返回 → 滑正文；全屏视频 → 退出 → 滑列表
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa9e02b3-7164-4048-a997-ec7a51fe8f84?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa9e02b3-7164-4048-a997-ec7a51fe8f84&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

