### PR TITLE
fix(sync): 修复同一设备重复出现在设备列表

### DIFF
--- a/cloud/src/routes/devices.ts
+++ b/cloud/src/routes/devices.ts
@@ -5,12 +5,17 @@
 
 import type { FastifyInstance, FastifyRequest } from 'fastify'
 
-import { uuidSchema, type DeviceListResponse } from '@newsnook/contracts'
+import { uuidSchema, type DeviceContext, type DeviceListResponse } from '@newsnook/contracts'
 
 import { validationFailed } from '../errors.js'
 import type { SyncService } from '../sync/service.js'
 
 export const DEVICE_HEADER = 'x-newsnook-device'
+export const DEVICE_NAME_HEADER = 'x-newsnook-device-name'
+export const DEVICE_PLATFORM_HEADER = 'x-newsnook-device-platform'
+export const APP_VERSION_HEADER = 'x-newsnook-app-version'
+
+const PLATFORM_VALUES = new Set(['web', 'android', 'ios', 'unknown'])
 
 export interface DeviceRouteOptions {
   service: SyncService
@@ -24,6 +29,32 @@ export function deviceIdFromHeader(request: FastifyRequest): string | null {
   return uuidSchema.safeParse(value).success ? value : null
 }
 
+function readHeader(request: FastifyRequest, name: string, maxLength: number): string | undefined {
+  const raw = request.headers[name]
+  const value = Array.isArray(raw) ? raw[0] : raw
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed ? trimmed.slice(0, maxLength) : undefined
+}
+
+/** 每条同步/设备请求都带上本机型号与平台，便于刷新 devices 行 */
+export function deviceContextFromRequest(
+  request: FastifyRequest,
+  deviceId: string,
+): DeviceContext {
+  const platformRaw = readHeader(request, DEVICE_PLATFORM_HEADER, 16)
+  const platform =
+    platformRaw && PLATFORM_VALUES.has(platformRaw)
+      ? (platformRaw as DeviceContext['platform'])
+      : undefined
+  return {
+    deviceId,
+    deviceName: readHeader(request, DEVICE_NAME_HEADER, 120),
+    platform,
+    appVersion: readHeader(request, APP_VERSION_HEADER, 40),
+  }
+}
+
 export async function registerDeviceRoutes(
   app: FastifyInstance,
   options: DeviceRouteOptions,
@@ -33,9 +64,17 @@ export async function registerDeviceRoutes(
     { config: { rateLimit: { max: 60, timeWindow: '1 minute' } } },
     async (request): Promise<DeviceListResponse> => {
       const session = await app.requireSession(request)
+      const deviceId = deviceIdFromHeader(request)
+      if (deviceId) {
+        await options.service.ensureDevice(
+          session.userId,
+          deviceContextFromRequest(request, deviceId),
+          session.sessionId,
+        )
+      }
       const devices = await options.service.listDevices(
         session.userId,
-        deviceIdFromHeader(request),
+        deviceId,
       )
       return { devices }
     },

--- a/cloud/src/routes/sync.ts
+++ b/cloud/src/routes/sync.ts
@@ -19,7 +19,7 @@ import {
 
 import { protocolUnsupported, validationFailed } from '../errors.js'
 import type { SyncService } from '../sync/service.js'
-import { deviceIdFromHeader } from './devices.js'
+import { deviceContextFromRequest, deviceIdFromHeader } from './devices.js'
 
 export interface SyncRouteOptions {
   service: SyncService
@@ -57,7 +57,11 @@ export async function registerSyncRoutes(
     async (request) => {
       const session = await app.requireSession(request)
       const deviceId = requireDeviceId(request)
-      await service.ensureDevice(session.userId, { deviceId }, session.sessionId)
+      await service.ensureDevice(
+        session.userId,
+        deviceContextFromRequest(request, deviceId),
+        session.sessionId,
+      )
       return service.bootstrap(session.userId)
     },
   )
@@ -74,7 +78,11 @@ export async function registerSyncRoutes(
       if (!parsed.success) throw validationFailed('首次同步请求无效')
 
       const deviceId = requireDeviceId(request, parsed.data.deviceId)
-      await service.ensureDevice(session.userId, { deviceId }, session.sessionId)
+      await service.ensureDevice(
+        session.userId,
+        deviceContextFromRequest(request, deviceId),
+        session.sessionId,
+      )
       return service.bootstrapReplace(session.userId, deviceId, parsed.data.entities)
     },
   )
@@ -97,13 +105,14 @@ export async function registerSyncRoutes(
       }
 
       const deviceId = requireDeviceId(request, parsed.data.deviceId)
+      const headerContext = deviceContextFromRequest(request, deviceId)
       await service.ensureDevice(
         session.userId,
         {
           deviceId,
-          deviceName: parsed.data.deviceName,
-          platform: parsed.data.platform,
-          appVersion: parsed.data.appVersion,
+          deviceName: parsed.data.deviceName ?? headerContext.deviceName,
+          platform: parsed.data.platform ?? headerContext.platform,
+          appVersion: parsed.data.appVersion ?? headerContext.appVersion,
         },
         session.sessionId,
       )
@@ -137,7 +146,11 @@ export async function registerSyncRoutes(
     if (!parsed.success) throw validationFailed('同步拉取参数无效')
 
     const deviceId = requireDeviceId(request)
-    await service.ensureDevice(session.userId, { deviceId }, session.sessionId)
+    await service.ensureDevice(
+      session.userId,
+      deviceContextFromRequest(request, deviceId),
+      session.sessionId,
+    )
 
     const startedAt = Date.now()
     const result = await service.pull(session.userId, parsed.data.since, parsed.data.limit)
@@ -164,7 +177,11 @@ export async function registerSyncRoutes(
     async (request): Promise<SyncConflictListResponse> => {
       const session = await app.requireSession(request)
       const deviceId = requireDeviceId(request)
-      await service.ensureDevice(session.userId, { deviceId }, session.sessionId)
+      await service.ensureDevice(
+        session.userId,
+        deviceContextFromRequest(request, deviceId),
+        session.sessionId,
+      )
       return { conflicts: await service.listConflicts(session.userId) }
     },
   )
@@ -178,7 +195,11 @@ export async function registerSyncRoutes(
     if (!parsed.success) throw validationFailed('冲突批量处理请求无效')
 
     const deviceId = requireDeviceId(request, parsed.data.deviceId)
-    await service.ensureDevice(session.userId, { deviceId }, session.sessionId)
+    await service.ensureDevice(
+      session.userId,
+      deviceContextFromRequest(request, deviceId),
+      session.sessionId,
+    )
 
     const result = await service.resolveConflicts(session.userId, parsed.data.decisions, deviceId)
     return {
@@ -201,7 +222,11 @@ export async function registerSyncRoutes(
       if (!parsed.success) throw validationFailed('冲突处理请求无效')
 
       const deviceId = requireDeviceId(request, parsed.data.deviceId)
-      await service.ensureDevice(session.userId, { deviceId }, session.sessionId)
+      await service.ensureDevice(
+        session.userId,
+        deviceContextFromRequest(request, deviceId),
+        session.sessionId,
+      )
 
       const result = await service.resolveConflict(
         session.userId,

--- a/cloud/src/sync/repository.ts
+++ b/cloud/src/sync/repository.ts
@@ -645,7 +645,10 @@ export async function touchDevice(
      VALUES ($1, $2, $3, $4, $5, now())
      ON CONFLICT (id) DO UPDATE SET
        name = COALESCE(EXCLUDED.name, devices.name),
-       platform = COALESCE(EXCLUDED.platform, devices.platform),
+       platform = CASE
+         WHEN EXCLUDED.platform IS NOT NULL AND EXCLUDED.platform <> 'unknown' THEN EXCLUDED.platform
+         ELSE devices.platform
+       END,
        app_version = COALESCE(EXCLUDED.app_version, devices.app_version),
        last_seen_at = now()`,
     [

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "test:account-auth": "npx tsx scripts/account-auth.test.ts",
     "test:secure-secret-hydration": "npx tsx scripts/secure-secret-hydration.test.ts",
     "test:cloud-sync-runtime": "npx tsx scripts/cloud-sync-runtime.test.ts",
+    "test:device-identity": "npx tsx scripts/device-identity.test.ts",
     "test:account-sync-ui": "npm run build:contracts && npx tsx scripts/account-sync-ui.test.ts",
     "test:sync-notifier": "npm run build:contracts && npx tsx scripts/sync-notifier.test.ts"
   },

--- a/scripts/device-identity.test.ts
+++ b/scripts/device-identity.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict'
+
+import {
+  assignDeviceId,
+  deviceDisplayName,
+  devicePlatform,
+  resolveDeviceId,
+} from '../src/features/sync/deviceIdentity'
+import { createInitialSyncState, readSyncState, writeSyncState } from '../src/features/sync/state'
+import { loadPersistedDeviceId, savePersistedDeviceId } from '../src/lib/storage'
+
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>()
+
+  get length(): number {
+    return this.values.size
+  }
+
+  clear(): void {
+    this.values.clear()
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null
+  }
+
+  key(index: number): string | null {
+    return [...this.values.keys()][index] ?? null
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key)
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, String(value))
+  }
+}
+
+const memory = new MemoryStorage()
+Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: memory })
+
+Object.defineProperty(globalThis, 'navigator', {
+  configurable: true,
+  value: {
+    userAgent:
+      'Mozilla/5.0 (Linux; Android 14; 2210132C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+  },
+})
+
+memory.clear()
+const first = resolveDeviceId()
+assert.match(first, /^[0-9a-f-]{36}$/)
+assert.equal(loadPersistedDeviceId(), first)
+
+memory.clear()
+savePersistedDeviceId('11111111-2222-4333-8444-555555555555')
+assert.equal(resolveDeviceId(), '11111111-2222-4333-8444-555555555555')
+
+writeSyncState(
+  createInitialSyncState('22222222-3333-4444-8555-666666666666'),
+)
+assert.equal(readSyncState().deviceId, '22222222-3333-4444-8555-666666666666')
+assert.equal(loadPersistedDeviceId(), '22222222-3333-4444-8555-666666666666')
+
+removeSyncStateOnly()
+assert.equal(
+  resolveDeviceId(),
+  '22222222-3333-4444-8555-666666666666',
+  'sync-state 丢失后仍应复用独立持久化的 deviceId',
+)
+
+assert.equal(deviceDisplayName(), '2210132C')
+assert.equal(devicePlatform(), 'android')
+
+function removeSyncStateOnly(): void {
+  memory.removeItem('newsnook:sync-state:v1')
+}
+
+assignDeviceId('33333333-4444-4555-8666-777777777777')
+assert.equal(loadPersistedDeviceId(), '33333333-4444-4555-8666-777777777777')
+
+console.log('device-identity: ok')

--- a/src/features/sync/SyncEngine.ts
+++ b/src/features/sync/SyncEngine.ts
@@ -12,7 +12,7 @@ import type { BootstrapEntity, SyncConflict, SyncPushResponse, SyncRecord } from
 
 import { log } from '../../lib/logger'
 import { fingerprintOf } from './fingerprint'
-import { randomUuid } from './ids'
+import { rotateDeviceId } from './state'
 import { materializeBatch } from './reconcile'
 import { reconcileProjection } from './reconcile'
 import { SyncTransportError, type SyncTransport } from './transport'
@@ -414,9 +414,9 @@ export class SyncEngine {
 
     if (transportError.code === 'DEVICE_IN_USE') {
       // 同机换账号：旧 deviceId 还挂在别的用户上。换新 id 立刻再试，不打扰用户。
+      rotateDeviceId()
       this.adapter.writeState({
-        ...state,
-        deviceId: randomUuid(),
+        ...this.adapter.readState(),
         retryAttempt: 0,
         nextRetryAt: this.now(),
       })

--- a/src/features/sync/deviceIdentity.ts
+++ b/src/features/sync/deviceIdentity.ts
@@ -1,0 +1,82 @@
+/**
+ * 设备身份：本机 deviceId 与展示名。
+ *
+ * deviceId 单独持久化，避免 sync-state 被清空或重建时向云端登记成「新设备」。
+ * 只有换账号冲突（DEVICE_IN_USE）或用户主动撤销后才轮换。
+ */
+
+import { Capacitor } from '@capacitor/core'
+import type { DevicePlatform } from '@newsnook/contracts'
+
+import { loadPersistedDeviceId, savePersistedDeviceId } from '../../lib/storage'
+import { randomUuid } from './ids'
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function isUuid(value: string): boolean {
+  return UUID_PATTERN.test(value)
+}
+
+export function devicePlatform(): DevicePlatform {
+  const platform = Capacitor.getPlatform()
+  if (platform === 'android') return 'android'
+  if (platform === 'ios') return 'ios'
+  if (platform === 'web') {
+    if (typeof navigator !== 'undefined' && /Android/i.test(navigator.userAgent)) return 'android'
+    return 'web'
+  }
+  return 'unknown'
+}
+
+/** 从 UA 提取 Android 型号；WebView 里通常形如 `… Android 14; 2210132C Build/…` */
+export function deviceDisplayName(): string {
+  if (typeof navigator === 'undefined') return 'NewsNook'
+
+  const ua = navigator.userAgent
+  const androidModel = /Android[^;]*;\s*([^)]+)\)/.exec(ua)?.[1]?.split(' Build')[0]?.trim()
+  if (androidModel) return androidModel.slice(0, 60)
+
+  const platform = devicePlatform()
+  if (platform === 'web') {
+    if (/Mobile/i.test(ua)) return '移动浏览器'
+    if (/Windows/i.test(ua)) return 'Windows 浏览器'
+    if (/Mac OS X/i.test(ua)) return 'Mac 浏览器'
+    return '网页浏览器'
+  }
+
+  if (platform === 'android') return 'Android 设备'
+  if (platform === 'ios') return 'iPhone / iPad'
+  return 'NewsNook'
+}
+
+/** 优先 sync-state 里的 id，其次独立持久化键，最后才生成新 UUID。 */
+export function resolveDeviceId(syncStateDeviceId?: string | null): string {
+  if (syncStateDeviceId && isUuid(syncStateDeviceId)) {
+    savePersistedDeviceId(syncStateDeviceId)
+    return syncStateDeviceId
+  }
+
+  const persisted = loadPersistedDeviceId()
+  if (persisted && isUuid(persisted)) return persisted
+
+  const created = randomUuid()
+  savePersistedDeviceId(created)
+  return created
+}
+
+export function assignDeviceId(deviceId: string): void {
+  if (!isUuid(deviceId)) return
+  savePersistedDeviceId(deviceId)
+}
+
+export function readDeviceIdentity(): {
+  deviceName: string
+  platform: DevicePlatform
+  appVersion: string
+} {
+  return {
+    deviceName: deviceDisplayName(),
+    platform: devicePlatform(),
+    appVersion: typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : '',
+  }
+}

--- a/src/features/sync/devices.ts
+++ b/src/features/sync/devices.ts
@@ -5,15 +5,46 @@
 
 import type { DeviceListResponse, DeviceSummary } from '@newsnook/contracts'
 
+import { readDeviceIdentity } from './deviceIdentity'
 import type { CloudFetch } from './transport'
-import { DEVICE_HEADER } from './transport'
+import {
+  APP_VERSION_HEADER,
+  DEVICE_HEADER,
+  DEVICE_NAME_HEADER,
+  DEVICE_PLATFORM_HEADER,
+} from './transport'
+
+export function formatDeviceLabel(device: DeviceSummary): string {
+  if (device.name?.trim()) return device.name.trim()
+  if (device.platform === 'android') return 'Android 设备'
+  if (device.platform === 'ios') return 'iPhone / iPad'
+  if (device.platform === 'web') return '网页浏览器'
+  return '未命名设备'
+}
+
+export function devicePlatformLabel(platform: DeviceSummary['platform']): string {
+  if (platform === 'android') return 'Android'
+  if (platform === 'web') return '网页'
+  if (platform === 'ios') return 'iOS'
+  return '其它'
+}
+
+function deviceRequestHeaders(deviceId: string): Record<string, string> {
+  const meta = readDeviceIdentity()
+  return {
+    [DEVICE_HEADER]: deviceId,
+    [DEVICE_NAME_HEADER]: meta.deviceName,
+    [DEVICE_PLATFORM_HEADER]: meta.platform,
+    [APP_VERSION_HEADER]: meta.appVersion,
+  }
+}
 
 export async function listDevices(
   fetchCloud: CloudFetch,
   currentDeviceId: string,
 ): Promise<DeviceSummary[]> {
   const response = await fetchCloud('/api/v1/devices', {
-    headers: { [DEVICE_HEADER]: currentDeviceId },
+    headers: deviceRequestHeaders(currentDeviceId),
   })
   if (!response.ok) throw new Error(`设备列表读取失败（${response.status}）`)
   const body = (await response.json()) as DeviceListResponse
@@ -24,12 +55,13 @@ export async function revokeDevice(fetchCloud: CloudFetch, deviceId: string): Pr
   const response = await fetchCloud(`/api/v1/devices/${encodeURIComponent(deviceId)}/revoke`, {
     method: 'POST',
     body: {},
+    headers: deviceRequestHeaders(deviceId),
   })
   if (!response.ok) throw new Error(`撤销失败（${response.status}）`)
 }
 
 export function describeDevice(device: DeviceSummary, now = Date.now()): string {
-  const platform = device.platform === 'android' ? 'Android' : device.platform === 'web' ? '网页' : '其它'
+  const platform = devicePlatformLabel(device.platform)
   if (device.revokedAt) return `${platform} · 已撤销`
   const idle = Math.max(0, now - device.lastSeenAt)
   const minutes = Math.floor(idle / 60_000)

--- a/src/features/sync/state.ts
+++ b/src/features/sync/state.ts
@@ -16,6 +16,7 @@ import {
   saveSyncJournal,
   saveSyncState,
 } from '../../lib/storage'
+import { assignDeviceId, resolveDeviceId } from './deviceIdentity'
 import { randomUuid } from './ids'
 import type {
   ConflictMarker,
@@ -28,7 +29,8 @@ import type {
 const ENTITY_TYPES: SyncEntityType[] = ['subscription', 'category', 'setting', 'secret']
 const OPERATIONS: SyncMutationOperation[] = ['upsert', 'delete']
 
-export function createInitialSyncState(deviceId = randomUuid()): LocalSyncState {
+export function createInitialSyncState(deviceId = resolveDeviceId()): LocalSyncState {
+  assignDeviceId(deviceId)
   return {
     deviceId,
     cursor: 0,
@@ -110,7 +112,9 @@ function normalizeOutbox(raw: unknown): OutboxEntry[] {
 
 export function normalizeSyncState(raw: unknown): LocalSyncState {
   const input = (raw ?? {}) as Partial<LocalSyncState>
-  const deviceId = typeof input.deviceId === 'string' && input.deviceId ? input.deviceId : randomUuid()
+  const deviceId = resolveDeviceId(
+    typeof input.deviceId === 'string' && input.deviceId ? input.deviceId : null,
+  )
 
   return {
     deviceId,
@@ -145,6 +149,7 @@ export function readSyncState(): LocalSyncState {
 }
 
 export function writeSyncState(state: LocalSyncState): void {
+  assignDeviceId(state.deviceId)
   saveSyncState(redactForPersistence(state))
 }
 
@@ -152,6 +157,7 @@ export function writeSyncState(state: LocalSyncState): void {
 export function rotateDeviceId(): string {
   const state = readSyncState()
   const deviceId = randomUuid()
+  assignDeviceId(deviceId)
   writeSyncState({ ...state, deviceId })
   log.sync.info('rotated device id after ownership conflict')
   return deviceId

--- a/src/features/sync/transport.ts
+++ b/src/features/sync/transport.ts
@@ -21,6 +21,9 @@ import type {
 } from '@newsnook/contracts'
 
 export const DEVICE_HEADER = 'x-newsnook-device'
+export const DEVICE_NAME_HEADER = 'x-newsnook-device-name'
+export const DEVICE_PLATFORM_HEADER = 'x-newsnook-device-platform'
+export const APP_VERSION_HEADER = 'x-newsnook-app-version'
 
 /** 网络层失败与业务错误码统一成这一个类型，引擎据此决定重试还是暂停 */
 export class SyncTransportError extends Error {
@@ -127,12 +130,23 @@ export function createHttpSyncTransport(options: {
    * `deviceId` 只解析一次：服务端要求请求头与请求体里的设备标识一致，
    * 两处各读一次状态的话，正好赶上换 id 的那一刻就会自相矛盾。
    */
+  function deviceHeaders(deviceId?: string): Record<string, string> {
+    const device = identity()
+    const headers: Record<string, string> = {
+      [DEVICE_HEADER]: deviceId ?? device.deviceId,
+    }
+    if (device.deviceName) headers[DEVICE_NAME_HEADER] = device.deviceName
+    if (device.platform) headers[DEVICE_PLATFORM_HEADER] = device.platform
+    if (device.appVersion) headers[APP_VERSION_HEADER] = device.appVersion
+    return headers
+  }
+
   async function call<T>(path: string, init?: CloudRequestInit, deviceId?: string): Promise<T> {
     let response: Response
     try {
       response = await fetchCloud(path, {
         ...init,
-        headers: { ...init?.headers, [DEVICE_HEADER]: deviceId ?? identity().deviceId },
+        headers: { ...deviceHeaders(deviceId), ...init?.headers },
       })
     } catch (error) {
       throw new SyncTransportError({

--- a/src/features/sync/useCloudSync.ts
+++ b/src/features/sync/useCloudSync.ts
@@ -9,13 +9,13 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { App as CapacitorApp } from '@capacitor/app'
-import { Capacitor } from '@capacitor/core'
 import type { SyncConflict } from '@newsnook/contracts'
 
 import { log } from '../../lib/logger'
 import type { Preferences } from '../../sources/preferences'
 import type { PresetsState } from '../../sources/presets'
 import type { AccountAdapter } from '../account/types'
+import { readDeviceIdentity } from './deviceIdentity'
 import type { LocalRuntimeState } from './merge'
 import { notifySyncEvent } from './nativeNotification'
 import { projectLocalState } from './projection'
@@ -64,20 +64,9 @@ const IDLE_STATUS: SyncStatus = {
   firstSyncCompleted: false,
 }
 
-function devicePlatform(): 'android' | 'web' {
-  return Capacitor.getPlatform() === 'android' ? 'android' : 'web'
-}
-
 function appVisibility(): 'foreground' | 'background' {
   if (typeof document === 'undefined') return 'background'
   return document.visibilityState === 'visible' ? 'foreground' : 'background'
-}
-
-function deviceName(): string {
-  if (typeof navigator === 'undefined') return 'NewsNook'
-  const ua = navigator.userAgent
-  const model = /Android[^;]*;\s*([^)]+)\)/.exec(ua)?.[1]?.split(' Build')[0]
-  return (model ?? (devicePlatform() === 'android' ? 'Android' : 'Web')).slice(0, 60)
 }
 
 export function useCloudSync(args: CloudSyncArgs): CloudSyncApi {
@@ -124,9 +113,7 @@ export function useCloudSync(args: CloudSyncArgs): CloudSyncApi {
       fetchCloud: account.fetchCloud,
       identity: () => ({
         deviceId: readSyncState().deviceId,
-        deviceName: deviceName(),
-        platform: devicePlatform(),
-        appVersion: __APP_VERSION__,
+        ...readDeviceIdentity(),
       }),
     })
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -19,6 +19,8 @@ const LOCAL_CACHE_PREFIXES = [LIST_CACHE_PREFIX, 'body:']
  */
 export const SYNC_STATE_KEY = 'sync-state:v1'
 export const SYNC_JOURNAL_KEY = 'sync-journal:v1'
+/** 与 sync-state 分开存，避免同步域重置时向云端登记成新设备 */
+export const DEVICE_ID_KEY = 'device-id'
 export const SYNC_ONBOARDING_KEY = 'sync-onboarding-seen'
 /** 首次同步基线选择前的本机快照，只落 localStorage（见 lib/backup.ts） */
 export const SYNC_SAFETY_SNAPSHOT_KEY = 'sync-safety-snapshot:v1'
@@ -39,6 +41,7 @@ const BOOTSTRAP_MIRROR_KEYS = [
   'appUpdate',
   SYNC_STATE_KEY,
   SYNC_JOURNAL_KEY,
+  DEVICE_ID_KEY,
   SYNC_ONBOARDING_KEY,
 ] as const
 
@@ -271,6 +274,15 @@ export function loadSyncState(): unknown {
 
 export function saveSyncState(state: unknown): void {
   write(SYNC_STATE_KEY, state)
+}
+
+export function loadPersistedDeviceId(): string | null {
+  const value = read<string | null>(DEVICE_ID_KEY, null)
+  return typeof value === 'string' && value ? value : null
+}
+
+export function savePersistedDeviceId(deviceId: string): void {
+  write(DEVICE_ID_KEY, deviceId)
 }
 
 export function clearSyncState(): void {

--- a/src/screens/settings/AccountSyncScreen.tsx
+++ b/src/screens/settings/AccountSyncScreen.tsx
@@ -27,7 +27,7 @@ import type { AccountApi } from '../../features/account/useAccount'
 import type { SocialProvider } from '../../features/account/types'
 import { ConflictResolutionSheet } from '../../features/sync/ConflictResolutionSheet'
 import { CONFLICT_ENTITY_LABEL, summarizeConflicts } from '../../features/sync/conflictView'
-import { describeDevice, listDevices, revokeDevice } from '../../features/sync/devices'
+import { describeDevice, formatDeviceLabel, listDevices, revokeDevice } from '../../features/sync/devices'
 import {
   countProjection,
   decideFirstSync,
@@ -138,6 +138,7 @@ export function AccountSyncScreen({ account, sync, runtime, onBack }: Props) {
   const [confirmChoice, setConfirmChoice] = useState<FirstSyncChoice | null>(null)
   const [devices, setDevices] = useState<DeviceSummary[] | null>(null)
   const [deviceError, setDeviceError] = useState<string | null>(null)
+  const [showRevokedDevices, setShowRevokedDevices] = useState(false)
   const [revokeTarget, setRevokeTarget] = useState<DeviceSummary | null>(null)
   const [revoking, setRevoking] = useState(false)
   const [conflictSheetOpen, setConflictSheetOpen] = useState(false)
@@ -722,46 +723,76 @@ export function AccountSyncScreen({ account, sync, runtime, onBack }: Props) {
                     正在读取设备列表…
                   </p>
                 )}
-                <ul className="divide-y divide-haze/60">
-                  {devices?.map((device) => (
-                    <li key={device.id} className="flex items-center gap-3 py-3 first:pt-0 last:pb-0">
-                      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-haze bg-ink">
-                        {device.platform === 'android' ? (
-                          <Smartphone size={15} strokeWidth={1.6} className="text-paper-muted" />
-                        ) : (
-                          <Monitor size={15} strokeWidth={1.6} className="text-paper-muted" />
-                        )}
-                      </span>
-                      <span className="min-w-0 flex-1">
-                        <span className="flex items-center gap-1.5">
-                          <span className="truncate text-[13.5px] text-paper">
-                            {device.name ?? '未命名设备'}
-                          </span>
-                          {device.current && (
-                            <span className="shrink-0 rounded-full border border-cinnabar/50 bg-cinnabar/10 px-2 py-0.5 font-mono text-[9px] tracking-[0.1em] text-cinnabar-soft">
-                              本机
-                            </span>
+                {devices && (
+                  <>
+                    {(() => {
+                      const active = devices.filter((device) => !device.revokedAt)
+                      const revoked = devices.filter((device) => device.revokedAt)
+                      const visibleRevoked = showRevokedDevices ? revoked : []
+                      const rows = [...active, ...visibleRevoked]
+                      return (
+                        <>
+                          {active.length === 0 && revoked.length > 0 && !showRevokedDevices && (
+                            <p className="mb-3 text-[12px] leading-relaxed text-paper-muted">
+                              当前没有活跃设备。若你只在用这一台手机，展开下方已撤销条目并清理重复记录即可。
+                            </p>
                           )}
-                        </span>
-                        <span className="mt-0.5 block truncate font-mono text-[10px] text-paper-faint">
-                          {describeDevice(device)}
-                          {device.appVersion ? ` · v${device.appVersion}` : ''}
-                        </span>
-                      </span>
-                      {!device.current && !device.revokedAt && (
-                        <button
-                          type="button"
-                          onClick={() => setRevokeTarget(device)}
-                          className={`${SECONDARY_BUTTON} shrink-0`}
-                        >
-                          撤销
-                        </button>
-                      )}
-                    </li>
-                  ))}
-                </ul>
+                          <ul className="divide-y divide-haze/60">
+                            {rows.map((device) => (
+                              <li key={device.id} className="flex items-center gap-3 py-3 first:pt-0 last:pb-0">
+                                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-haze bg-ink">
+                                  {device.platform === 'android' || device.platform === 'ios' ? (
+                                    <Smartphone size={15} strokeWidth={1.6} className="text-paper-muted" />
+                                  ) : (
+                                    <Monitor size={15} strokeWidth={1.6} className="text-paper-muted" />
+                                  )}
+                                </span>
+                                <span className="min-w-0 flex-1">
+                                  <span className="flex items-center gap-1.5">
+                                    <span className="truncate text-[13.5px] text-paper">
+                                      {formatDeviceLabel(device)}
+                                    </span>
+                                    {device.current && (
+                                      <span className="shrink-0 rounded-full border border-cinnabar/50 bg-cinnabar/10 px-2 py-0.5 font-mono text-[9px] tracking-[0.1em] text-cinnabar-soft">
+                                        本机
+                                      </span>
+                                    )}
+                                  </span>
+                                  <span className="mt-0.5 block truncate font-mono text-[10px] text-paper-faint">
+                                    {describeDevice(device)}
+                                    {device.appVersion ? ` · v${device.appVersion}` : ''}
+                                  </span>
+                                </span>
+                                {!device.current && !device.revokedAt && (
+                                  <button
+                                    type="button"
+                                    onClick={() => setRevokeTarget(device)}
+                                    className={`${SECONDARY_BUTTON} shrink-0`}
+                                  >
+                                    撤销
+                                  </button>
+                                )}
+                              </li>
+                            ))}
+                          </ul>
+                          {revoked.length > 0 && (
+                            <button
+                              type="button"
+                              onClick={() => setShowRevokedDevices((open) => !open)}
+                              className="mt-3 text-[11px] text-paper-muted underline-offset-2 hover:text-paper hover:underline"
+                            >
+                              {showRevokedDevices
+                                ? '收起已撤销设备'
+                                : `查看已撤销设备（${revoked.length}）`}
+                            </button>
+                          )}
+                        </>
+                      )
+                    })()}
+                  </>
+                )}
                 <p className="mt-3 border-t border-haze/60 pt-3 text-[11px] leading-relaxed text-paper-faint">
-                  撤销只让那台设备停止云端同步，它本机已有的订阅与配置照旧可用。
+                  撤销只让那台设备停止云端同步，它本机已有的订阅与配置照旧可用。同一台手机若出现多条记录，通常是历史遗留，保留带「本机」的一条即可。
                 </p>
               </Card>
             </div>
@@ -889,7 +920,7 @@ export function AccountSyncScreen({ account, sync, runtime, onBack }: Props) {
       <ConfirmDialog
         open={revokeTarget !== null}
         title="撤销这台设备？"
-        message={`「${revokeTarget?.name ?? '未命名设备'}」将停止云端同步，它本机已有的订阅与配置照旧可用；之后重新登录即可恢复同步。`}
+        message={`「${revokeTarget ? formatDeviceLabel(revokeTarget) : '未命名设备'}」将停止云端同步，它本机已有的订阅与配置照旧可用；之后重新登录即可恢复同步。`}
         confirmLabel={revoking ? '撤销中…' : '撤销'}
         onConfirm={() => void confirmRevoke()}
         onCancel={() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

同一台物理设备登录后，设备列表出现多条记录（含「未命名设备」、重复的 `2210132C`、平台显示「其它」），用户实际只有一台设备。

## 根因

1. **deviceId 不稳定**：仅存于 `sync-state:v1`，该结构被清空/重建时会 `randomUuid()` 生成新 ID，云端 `ensureDevice` 按新 UUID 插入新行 → 同一手机多条记录。
2. **元数据未随请求刷新**：bootstrap / pull / conflicts 等路由只传 `{ deviceId }`，首登或早期同步会把设备登记为 `name=null`、`platform=unknown`（UI 显示「未命名设备」「其它」）。
3. **历史遗留**：已撤销的旧 UUID 仍展示在列表中，加剧「很多设备」的观感。

## 修复

### 客户端
- 新增 `deviceIdentity.ts`：独立持久化 `newsnook:device-id`（进 Android 冷启动镜像），`resolveDeviceId()` 优先复用
- 所有同步/设备请求附带 `x-newsnook-device-name/platform/app-version` 头
- 从 UA 优先解析 Android 型号（如 `2210132C`）；WebView 下从 UA 推断 android 平台
- 设备列表默认隐藏已撤销项，附说明文案

### 服务端
- 所有 `ensureDevice` 调用改为读取请求头中的设备上下文
- `GET /api/v1/devices` 打开列表前先 touch 本机，刷新名称/平台
- `touchDevice`：新 platform 非 unknown 时覆盖旧 unknown

## 验证

- `npm run test:device-identity` ✅
- `npm run test:cloud-sync-runtime` ✅
- `npm run lint` ✅

## 用户侧清理

更新后本机应稳定为一条「本机」记录。历史重复/未命名条目多为旧 UUID，可展开「查看已撤销设备」并撤销多余活跃项（保留带「本机」的一条）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa9e02b3-7164-4048-a997-ec7a51fe8f84?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa9e02b3-7164-4048-a997-ec7a51fe8f84&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

