### PR TITLE
fix(auth): 支持绑定多个社交 OAuth 账号

### DIFF
--- a/cloud/src/auth.ts
+++ b/cloud/src/auth.ts
@@ -17,6 +17,7 @@ import type { Pool } from 'pg'
 import { MOBILE_AUTH_CALLBACK_URL } from '@newsnook/contracts'
 
 import type { CloudConfig } from './config.js'
+import { listEnabledSocialOAuthProviders } from './config.js'
 import type { Mailer } from './mail.js'
 
 /** Linux DO Connect 的 OIDC discovery；回调路径为 /api/auth/callback/linuxdo */
@@ -125,8 +126,15 @@ export function createAuth(options: CreateAuthOptions) {
       },
     },
     account: {
-      // 同邮箱不静默合并：第三方身份必须由已登录账号显式绑定
-      accountLinking: { disableImplicitLinking: true },
+      // 同邮箱不静默合并：第三方身份必须由已登录账号显式绑定。
+      // 显式绑定时允许各平台邮箱不一致（Linux DO / GitHub 常用不同邮箱）；
+      // trustedProviders 覆盖 genericOAuth 的 linuxdo，避免未标记 verified 时被拒。
+      accountLinking: {
+        enabled: true,
+        disableImplicitLinking: true,
+        trustedProviders: listEnabledSocialOAuthProviders(config),
+        allowDifferentEmails: true,
+      },
     },
     socialProviders,
     advanced: {

--- a/cloud/tests/auth.test.ts
+++ b/cloud/tests/auth.test.ts
@@ -106,15 +106,39 @@ describe('auth', { skip: skipWithoutDatabase }, () => {
     // 直接模拟「另一个 provider 用同一个邮箱注册」：配置层已禁止隐式合并，
     // 这里断言配置确实生效，且不存在把两个身份并到同一 user 的路径。
     const options = cloud.app.newsnookAuth.options as {
-      account?: { accountLinking?: { disableImplicitLinking?: boolean } }
+      account?: {
+        accountLinking?: {
+          enabled?: boolean
+          disableImplicitLinking?: boolean
+          allowDifferentEmails?: boolean
+          trustedProviders?: string[]
+        }
+      }
     }
-    assert.equal(options.account?.accountLinking?.disableImplicitLinking, true)
+    const linking = options.account?.accountLinking
+    assert.equal(linking?.enabled, true)
+    assert.equal(linking?.disableImplicitLinking, true)
+    assert.equal(linking?.allowDifferentEmails, true, '显式绑定应允许各平台邮箱不一致')
 
     const { rows } = await cloud.pools.app.query<{ total: string }>(
       'SELECT count(*)::text AS total FROM auth."user" WHERE email = $1',
       [user.email],
     )
     assert.equal(rows[0]?.total, '1')
+  })
+
+  it('includes every enabled OAuth provider in accountLinking.trustedProviders', async () => {
+    const multiCloud = await startTestCloud({
+      github: { clientId: 'gh-test-id', clientSecret: 'gh-test-secret' },
+      linuxdo: { clientId: 'ld-test-id', clientSecret: 'ld-test-secret' },
+    })
+    const linking = (
+      multiCloud.app.newsnookAuth.options as {
+        account?: { accountLinking?: { trustedProviders?: string[] } }
+      }
+    ).account?.accountLinking
+    assert.deepEqual(linking?.trustedProviders, ['github', 'linuxdo'])
+    await multiCloud.close()
   })
 
   it('lists linked providers for the authenticated user', async () => {

--- a/scripts/account-auth.test.ts
+++ b/scripts/account-auth.test.ts
@@ -20,6 +20,10 @@ import {
   writeStoredSession,
 } from '../src/features/account/secureStore'
 import { AccountError } from '../src/features/account/types'
+import {
+  describeLinkedProvider,
+  describeOAuthCallbackError,
+} from '../src/features/account/oauthErrors'
 
 console.log('Testing account adapters...')
 
@@ -391,7 +395,8 @@ assert.equal(
     () => adapter.handleAuthDeepLink('newsnook://auth/callback?error=state_mismatch'),
     (error: unknown) => {
       assert.ok(error instanceof AccountError)
-      assert.equal(error.code, 'OAUTH_CALLBACK_FAILED')
+      assert.equal(error.code, 'state_mismatch')
+      assert.match(error.message, /授权状态/)
       return true
     },
   )
@@ -514,6 +519,14 @@ assert.equal(
 
   const result = await adapter.signUp({ email: 'new@example.test', password: 'correct-horse-1' })
   assert.equal(result.verificationRequired, true, '未返回会话即代表要先验证邮箱')
+}
+
+// --- OAuth 绑定错误与成功文案 -----------------------------------------------
+
+{
+  assert.match(describeOAuthCallbackError('email_does_not_match'), /邮箱/)
+  assert.match(describeLinkedProvider('github'), /GitHub/)
+  assert.match(describeLinkedProvider('linuxdo'), /Linux DO/)
 }
 
 console.log('All account adapter tests passed.')

--- a/src/features/account/authClient.ts
+++ b/src/features/account/authClient.ts
@@ -26,6 +26,7 @@ import {
   writeStoredSession,
   type SecureStore,
 } from './secureStore'
+import { describeOAuthCallbackError } from './oauthErrors'
 import {
   AccountError,
   type AccountAdapter,
@@ -291,7 +292,7 @@ export function createAccountAdapter(options: AccountAdapterOptions): AccountAda
 
       if (params.error) {
         log.account.warn('oauth callback failed', { code: params.error })
-        throw new AccountError('OAUTH_CALLBACK_FAILED', '第三方账号授权没能完成，请重试')
+        throw new AccountError(params.error, describeOAuthCallbackError(params.error))
       }
 
       if (params.linked) {

--- a/src/features/account/oauthErrors.ts
+++ b/src/features/account/oauthErrors.ts
@@ -1,0 +1,29 @@
+import type { SocialProvider } from './types'
+
+/** Better Auth OAuth 回调 `?error=` 码 → 面向用户的中文说明 */
+const OAUTH_CALLBACK_MESSAGES: Record<string, string> = {
+  state_mismatch: '授权状态对不上，请回到应用重新发起绑定',
+  email_does_not_match: '第三方账号邮箱与当前账户不一致，暂时无法绑定',
+  unable_to_link_account: '暂时无法绑定该第三方账号，请确认已在授权页完成登录',
+  account_already_linked_to_different_user: '该第三方账号已绑定到其他用户',
+  email_not_verified: '第三方账号邮箱尚未验证，请先在对应平台完成验证',
+  email_not_found: '第三方未返回邮箱，无法完成绑定',
+  oauth_provider_not_found: '该登录方式暂未启用',
+}
+
+const PROVIDER_LABEL: Record<SocialProvider, string> = {
+  google: 'Google',
+  github: 'GitHub',
+  linuxdo: 'Linux DO',
+}
+
+export function describeOAuthCallbackError(code: string): string {
+  return OAUTH_CALLBACK_MESSAGES[code] ?? '第三方账号授权没能完成，请重试'
+}
+
+export function describeLinkedProvider(provider: string): string {
+  if (provider in PROVIDER_LABEL) {
+    return `已绑定 ${PROVIDER_LABEL[provider as SocialProvider]}`
+  }
+  return '已绑定新的登录方式'
+}

--- a/src/features/account/useAccount.ts
+++ b/src/features/account/useAccount.ts
@@ -9,7 +9,8 @@ import { Capacitor } from '@capacitor/core'
 
 import { log } from '../../lib/logger'
 import { createPlatformAccountAdapter } from './authClient'
-import { isAuthCallbackUrl } from './mobileCallback'
+import { isAuthCallbackUrl, authCallbackFromAppUrl } from './mobileCallback'
+import { describeLinkedProvider, describeOAuthCallbackError } from './oauthErrors'
 import {
   AccountError,
   type AccountAdapter,
@@ -53,6 +54,14 @@ const ERROR_MESSAGES: Record<string, string> = {
   RATE_LIMITED: '操作太频繁，缓一会儿再试',
   SESSION_MISSING: '登录没能建立会话，请重试',
   OAUTH_URL_MISSING: '暂时无法开始第三方登录，稍后再试',
+  OAUTH_CALLBACK_FAILED: '第三方账号授权没能完成，请重试',
+  email_does_not_match: '第三方账号邮箱与当前账户不一致，暂时无法绑定',
+  unable_to_link_account: '暂时无法绑定该第三方账号，请确认已在授权页完成登录',
+  account_already_linked_to_different_user: '该第三方账号已绑定到其他用户',
+  email_not_verified: '第三方账号邮箱尚未验证，请先在对应平台完成验证',
+  LINKING_NOT_ALLOWED: '暂时无法绑定该登录方式',
+  LINKING_DIFFERENT_EMAILS_NOT_ALLOWED: '第三方账号邮箱与当前账户不一致，暂时无法绑定',
+  SOCIAL_ACCOUNT_ALREADY_LINKED: '该第三方账号已绑定到其他用户',
 }
 
 function describe(error: unknown): string {
@@ -114,13 +123,22 @@ export function useAccount(): AccountApi {
 
     const consume = (url: string) => {
       if (!isAuthCallbackUrl(url)) return
+      const callback = authCallbackFromAppUrl(url)
       void adapter
         .handleAuthDeepLink(url)
         .then((next) => {
-          if (next) settle(next)
+          if (!next || !mounted.current) return
+          settle(next)
+          if (callback?.linked) setNotice(describeLinkedProvider(callback.linked))
         })
         .catch((deepLinkError: unknown) => {
-          if (mounted.current) setError(describe(deepLinkError))
+          if (!mounted.current) return
+          if (deepLinkError instanceof AccountError && deepLinkError.code !== 'OAUTH_CALLBACK_FAILED') {
+            setError(ERROR_MESSAGES[deepLinkError.code] ?? deepLinkError.message)
+            return
+          }
+          const code = callback?.error
+          setError(code ? describeOAuthCallbackError(code) : describe(deepLinkError))
         })
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

绑定 Linux DO 后无法再绑定 GitHub 等第二个社交账号，回调常出现 `email_does_not_match`、`unable_to_link_account` 等错误。

## 根因

Better Auth 的 `accountLinking` 仅配置了 `disableImplicitLinking: true`，未显式启用完整的多 provider 显式绑定策略：

1. **`trustedProviders` 默认为空** — Linux DO（genericOAuth）等 provider 在邮箱未标记 verified 时，显式绑定会被拒绝
2. **`allowDifferentEmails` 默认为 false** — 各平台邮箱不一致（Linux DO / GitHub 常见）时，第二个 provider 绑定失败

## 改动

- **`cloud/src/auth.ts`**：完善 `accountLinking` 配置
  - `enabled: true`
  - `trustedProviders`: 动态取自已启用的 OAuth provider（google / github / linuxdo）
  - `allowDifferentEmails: true`（仅限已登录用户的显式绑定）
- **`src/features/account/oauthErrors.ts`**：OAuth 回调错误码中文映射
- **`authClient.ts` / `useAccount.ts`**：绑定失败时展示具体原因；绑定成功深链回流后提示「已绑定 GitHub」等
- **测试**：更新 `cloud/tests/auth.test.ts` 配置断言；`scripts/account-auth.test.ts` 覆盖错误文案

## 验证

- [x] `npm run test:account-auth`
- [x] `npm run lint`
- [ ] `npm run test:cloud`（本环境无 `TEST_DATABASE_URL`）

## 说明

仍保持 `disableImplicitLinking: true`：同邮箱 OAuth 登录不会静默合并账号，仅允许在「账户与同步 → 登录方式」里显式绑定。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa9e02b3-7164-4048-a997-ec7a51fe8f84?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa9e02b3-7164-4048-a997-ec7a51fe8f84&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

