### PR TITLE
perf(onboarding): 风格引导点选先画勾选，再延后预览主题

### DIFF
--- a/scripts/scheme-onboarding.test.ts
+++ b/scripts/scheme-onboarding.test.ts
@@ -7,7 +7,9 @@ import assert from 'node:assert/strict'
 import { parseHTML } from 'linkedom'
 
 import {
+  cancelScheduledPreview,
   previewThemeScheme,
+  schedulePreviewThemeScheme,
   schemeOnboardingOptions,
   shouldShowSchemeOnboarding,
 } from '../src/lib/schemeOnboarding'
@@ -77,6 +79,69 @@ assert.equal(document.documentElement.dataset.scheme, 'celadon')
 assert.equal(document.documentElement.classList.contains('theme-switching'), false)
 
 console.log('scheme-onboarding preview: ok')
+
+// 模拟浏览器帧循环：rAF 回调排队，flushFrame 走完一帧；两帧后才允许整页改写
+const frameQueue = new Map<number, () => void>()
+let frameSeq = 0
+;(globalThis as { requestAnimationFrame?: unknown }).requestAnimationFrame = (cb: () => void) => {
+  frameQueue.set(++frameSeq, cb)
+  return frameSeq
+}
+;(globalThis as { cancelAnimationFrame?: unknown }).cancelAnimationFrame = (id: number) => {
+  frameQueue.delete(id)
+}
+const flushFrame = () => {
+  const callbacks = [...frameQueue.values()]
+  frameQueue.clear()
+  for (const cb of callbacks) cb()
+}
+
+previewThemeScheme('ink')
+schedulePreviewThemeScheme('pearl')
+assert.equal(document.documentElement.dataset.scheme, 'ink', '点击当帧不改整页方案，先让选中态上屏')
+flushFrame()
+assert.equal(document.documentElement.dataset.scheme, 'ink', '本帧绘制前触发的 rAF 仍不写入')
+flushFrame()
+assert.equal(document.documentElement.dataset.scheme, 'pearl', '下一帧才落到 html[data-scheme]')
+assert.equal(document.documentElement.classList.contains('theme-switching'), false)
+
+schedulePreviewThemeScheme('celadon')
+schedulePreviewThemeScheme('pearl')
+schedulePreviewThemeScheme('ink')
+flushFrame()
+flushFrame()
+assert.equal(document.documentElement.dataset.scheme, 'ink', '连点多张卡只保留最后一张')
+assert.equal(frameQueue.size, 0, '被顶掉的预览不再占用帧回调')
+
+schedulePreviewThemeScheme('celadon')
+cancelScheduledPreview()
+flushFrame()
+flushFrame()
+assert.equal(document.documentElement.dataset.scheme, 'ink', '关闭/确认前取消后，迟到的预览不再写入')
+
+schedulePreviewThemeScheme('celadon')
+flushFrame()
+cancelScheduledPreview()
+flushFrame()
+assert.equal(document.documentElement.dataset.scheme, 'ink', '第二拍排队后取消同样有效')
+
+schedulePreviewThemeScheme('pearl')
+previewThemeScheme('celadon')
+flushFrame()
+flushFrame()
+assert.equal(
+  document.documentElement.dataset.scheme,
+  'pearl',
+  '未取消时延后预览照常落地（组件恢复基线前必须先取消）',
+)
+cancelScheduledPreview()
+
+delete (globalThis as { requestAnimationFrame?: unknown }).requestAnimationFrame
+delete (globalThis as { cancelAnimationFrame?: unknown }).cancelAnimationFrame
+schedulePreviewThemeScheme('celadon')
+assert.equal(document.documentElement.dataset.scheme, 'celadon', '没有 rAF 的环境退回同步写入')
+
+console.log('scheme-onboarding deferred preview: ok')
 
 const memory = new Map<string, string>()
 ;(globalThis as { localStorage?: unknown }).localStorage = {

--- a/src/components/SchemeOnboardingPrompt.tsx
+++ b/src/components/SchemeOnboardingPrompt.tsx
@@ -2,13 +2,19 @@ import { useCallback, useEffect, useId, useRef, useState, type MutableRefObject 
 import { Check, X } from 'lucide-react'
 
 import { lockBodyScroll } from '../lib/bodyScrollLock'
-import { previewThemeScheme, schemeOnboardingOptions } from '../lib/schemeOnboarding'
+import {
+  cancelScheduledPreview,
+  previewThemeScheme,
+  schedulePreviewThemeScheme,
+  schemeOnboardingOptions,
+} from '../lib/schemeOnboarding'
 import type { CustomSchemePrefs } from '../lib/customScheme'
 import type { ThemeScheme, ThemeSchemeSwatch } from '../lib/theme'
 
 /**
  * 风格选择：只出现一次，形态靠近同步介绍。
  * 点选只改 data-scheme 做预览；确认才写入偏好，「稍后再说」把画面拨回打开前。
+ * 预览延后一帧写入（见 schedulePreviewThemeScheme），点击帧只画卡片的选中态。
  */
 interface Props {
   open: boolean
@@ -66,6 +72,7 @@ export function SchemeOnboardingPrompt({
   }
 
   const restoreBaseline = useCallback(() => {
+    cancelScheduledPreview()
     previewThemeScheme(baselineRef.current, customScheme)
   }, [customScheme])
 
@@ -75,12 +82,15 @@ export function SchemeOnboardingPrompt({
   }, [onDismiss, restoreBaseline])
 
   const confirm = useCallback(() => {
+    // 确认后由偏好落盘统一套用方案；来不及落地的预览直接作废，免得两边抢写 data-scheme
+    cancelScheduledPreview()
     onConfirm(selected)
   }, [onConfirm, selected])
 
   useEffect(() => {
     if (!open) return
     setSelected(initialScheme)
+    return () => cancelScheduledPreview()
   }, [open, initialScheme])
 
   useEffect(() => {
@@ -161,7 +171,7 @@ export function SchemeOnboardingPrompt({
                   aria-pressed={checked}
                   onClick={() => {
                     setSelected(item.id)
-                    previewThemeScheme(item.id)
+                    schedulePreviewThemeScheme(item.id)
                   }}
                   className={`flex w-full flex-col gap-1.5 rounded-xl border p-2 text-left ${
                     checked ? 'border-cinnabar/60 bg-ink' : 'border-haze bg-ink/40'

--- a/src/lib/schemeOnboarding.ts
+++ b/src/lib/schemeOnboarding.ts
@@ -17,6 +17,36 @@ export function previewThemeScheme(scheme: ThemeScheme, custom?: CustomSchemePre
   applyThemeScheme(scheme, { animate: false, custom })
 }
 
+let cancelPendingPreview: (() => void) | undefined
+
+/**
+ * 点选后的预览分两拍：点击这一帧只让卡片的选中态上屏，整页 data-scheme 改写留到下一帧。
+ *
+ * 根上的 --tone-* 一变，全文档都要重算样式、重排、整屏重绘（数千节点的列表在慢机上是几百毫秒
+ * 到数秒）。若和点击落在同一帧，用户要等整页重排完才看到勾选，INP 被整段拖长。
+ * 事件里注册的 rAF 仍在本帧绘制前触发，因此要再嵌一层才真正落到本帧提交之后。
+ * 连点多张卡只保留最后一张；关闭或确认前调 cancelScheduledPreview，避免迟到的预览盖掉恢复/落盘结果。
+ */
+export function schedulePreviewThemeScheme(scheme: ThemeScheme, custom?: CustomSchemePrefs): void {
+  cancelScheduledPreview()
+  if (typeof requestAnimationFrame !== 'function') {
+    previewThemeScheme(scheme, custom)
+    return
+  }
+  let frame = requestAnimationFrame(() => {
+    frame = requestAnimationFrame(() => {
+      cancelPendingPreview = undefined
+      previewThemeScheme(scheme, custom)
+    })
+  })
+  cancelPendingPreview = () => cancelAnimationFrame(frame)
+}
+
+export function cancelScheduledPreview(): void {
+  cancelPendingPreview?.()
+  cancelPendingPreview = undefined
+}
+
 export function shouldShowSchemeOnboarding(input: {
   seen: boolean
   tab: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

「选择阅读风格」引导弹窗里切换主题卡片时，本地 INP 可到约 2s。根因是点击同帧同步写 `html[data-scheme]`，CSS 变量级联触发整页 `UpdateLayoutTree`/Layout/Paint，选中态边框与勾选被拖到同一帧之后才上屏。

## 改动

- 新增 `schedulePreviewThemeScheme`：嵌套 `requestAnimationFrame` 把 `data-scheme` 预览推到选中态提交之后；连点合并为最后一次；可取消。
- `SchemeOnboardingPrompt`：点选走延后预览；关闭/恢复/确认前取消待执行预览，避免迟到预览覆盖 baseline 或确认结果。
- 补充 `scheme-onboarding` 测试覆盖延后、连点合并、取消与无 rAF 回退。

## 验证

- `npm run test:scheme-onboarding`、`npm run test:theme` 通过
- Headless Chrome：无节流约 80–104 ms → 16 ms；4× CPU 约 296–352 ms → 24–40 ms（选中态先 paint，整页重算移到下一帧）

契约不变：点选只预览；「就用这个」写偏好；「稍后再说」恢复打开前方案。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-280748c8-aca4-4c8f-82b1-a678cec6ee11?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-280748c8-aca4-4c8f-82b1-a678cec6ee11&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

