### PR TITLE
perf(onboarding): 引导换主题时搁起 Feed，对齐外观页实时预览

### DIFF
--- a/scripts/scheme-onboarding.test.ts
+++ b/scripts/scheme-onboarding.test.ts
@@ -3,13 +3,13 @@
  * 运行：npm run test:scheme-onboarding
  */
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 
 import { parseHTML } from 'linkedom'
 
 import {
-  cancelScheduledPreview,
   previewThemeScheme,
-  schedulePreviewThemeScheme,
   schemeOnboardingOptions,
   shouldShowSchemeOnboarding,
 } from '../src/lib/schemeOnboarding'
@@ -80,68 +80,35 @@ assert.equal(document.documentElement.classList.contains('theme-switching'), fal
 
 console.log('scheme-onboarding preview: ok')
 
-// 模拟浏览器帧循环：rAF 回调排队，flushFrame 走完一帧；两帧后才允许整页改写
-const frameQueue = new Map<number, () => void>()
-let frameSeq = 0
-;(globalThis as { requestAnimationFrame?: unknown }).requestAnimationFrame = (cb: () => void) => {
-  frameQueue.set(++frameSeq, cb)
-  return frameSeq
-}
-;(globalThis as { cancelAnimationFrame?: unknown }).cancelAnimationFrame = (id: number) => {
-  frameQueue.delete(id)
-}
-const flushFrame = () => {
-  const callbacks = [...frameQueue.values()]
-  frameQueue.clear()
-  for (const cb of callbacks) cb()
-}
-
-previewThemeScheme('ink')
-schedulePreviewThemeScheme('pearl')
-assert.equal(document.documentElement.dataset.scheme, 'ink', '点击当帧不改整页方案，先让选中态上屏')
-flushFrame()
-assert.equal(document.documentElement.dataset.scheme, 'ink', '本帧绘制前触发的 rAF 仍不写入')
-flushFrame()
-assert.equal(document.documentElement.dataset.scheme, 'pearl', '下一帧才落到 html[data-scheme]')
-assert.equal(document.documentElement.classList.contains('theme-switching'), false)
-
-schedulePreviewThemeScheme('celadon')
-schedulePreviewThemeScheme('pearl')
-schedulePreviewThemeScheme('ink')
-flushFrame()
-flushFrame()
-assert.equal(document.documentElement.dataset.scheme, 'ink', '连点多张卡只保留最后一张')
-assert.equal(frameQueue.size, 0, '被顶掉的预览不再占用帧回调')
-
-schedulePreviewThemeScheme('celadon')
-cancelScheduledPreview()
-flushFrame()
-flushFrame()
-assert.equal(document.documentElement.dataset.scheme, 'ink', '关闭/确认前取消后，迟到的预览不再写入')
-
-schedulePreviewThemeScheme('celadon')
-flushFrame()
-cancelScheduledPreview()
-flushFrame()
-assert.equal(document.documentElement.dataset.scheme, 'ink', '第二拍排队后取消同样有效')
-
-schedulePreviewThemeScheme('pearl')
-previewThemeScheme('celadon')
-flushFrame()
-flushFrame()
-assert.equal(
-  document.documentElement.dataset.scheme,
-  'pearl',
-  '未取消时延后预览照常落地（组件恢复基线前必须先取消）',
+// 同步预览能即时的前提：引导期间 <main> 被搁起、遮罩不透明，整页改 data-scheme 只重画弹层和壳
+const css = readFileSync(resolve('src/index.css'), 'utf8')
+const parkedStart = css.indexOf('.content-parked {')
+assert.ok(parkedStart >= 0, 'index.css 缺少 .content-parked')
+assert.match(
+  css.slice(parkedStart, css.indexOf('\n}', parkedStart)),
+  /content-visibility:\s*hidden/,
+  '.content-parked 应用 content-visibility: hidden 让下层列表退出样式重算与绘制',
 )
-cancelScheduledPreview()
 
-delete (globalThis as { requestAnimationFrame?: unknown }).requestAnimationFrame
-delete (globalThis as { cancelAnimationFrame?: unknown }).cancelAnimationFrame
-schedulePreviewThemeScheme('celadon')
-assert.equal(document.documentElement.dataset.scheme, 'celadon', '没有 rAF 的环境退回同步写入')
+const appSource = readFileSync(resolve('src/App.tsx'), 'utf8')
+assert.match(
+  appSource,
+  /showSchemeOnboarding \? ' content-parked' : ''/,
+  '风格引导打开时 App 必须给 <main> 挂 content-parked',
+)
 
-console.log('scheme-onboarding deferred preview: ok')
+const promptSource = readFileSync(resolve('src/components/SchemeOnboardingPrompt.tsx'), 'utf8')
+assert.ok(
+  /fixed inset-0 z-\[65\][^"]*\bbg-ink\b/.test(promptSource),
+  '引导遮罩应为不透明 bg-ink：既盖住搁起的列表，也让整屏底色跟着预览变',
+)
+assert.ok(!promptSource.includes('bg-black/50'), '引导遮罩不再是半透明压暗层')
+assert.ok(
+  !promptSource.includes('schedulePreviewThemeScheme'),
+  '点选预览走同步 previewThemeScheme，不再延后到下一帧',
+)
+
+console.log('scheme-onboarding isolation: ok')
 
 const memory = new Map<string, string>()
 ;(globalThis as { localStorage?: unknown }).localStorage = {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1520,7 +1520,15 @@ export default function App() {
           onBrandTap={onBrandTap}
         />
 
-        <main className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-ink">
+        {/*
+          风格引导期间把内容区搁起（content-visibility: hidden）：下层今日列表不参与样式重算与绘制，
+          引导里点选预览才能像「我的 → 外观」那样即时；列表 DOM 与滚动位置照旧保留，关闭后原样回来。
+        */}
+        <main
+          className={`relative flex min-h-0 flex-1 flex-col overflow-hidden bg-ink${
+            showSchemeOnboarding ? ' content-parked' : ''
+          }`}
+        >
           {renderTab()}
 
           {!focusSource && (

--- a/src/components/SchemeOnboardingPrompt.tsx
+++ b/src/components/SchemeOnboardingPrompt.tsx
@@ -2,19 +2,16 @@ import { useCallback, useEffect, useId, useRef, useState, type MutableRefObject 
 import { Check, X } from 'lucide-react'
 
 import { lockBodyScroll } from '../lib/bodyScrollLock'
-import {
-  cancelScheduledPreview,
-  previewThemeScheme,
-  schedulePreviewThemeScheme,
-  schemeOnboardingOptions,
-} from '../lib/schemeOnboarding'
+import { previewThemeScheme, schemeOnboardingOptions } from '../lib/schemeOnboarding'
 import type { CustomSchemePrefs } from '../lib/customScheme'
 import type { ThemeScheme, ThemeSchemeSwatch } from '../lib/theme'
 
 /**
  * 风格选择：只出现一次，形态靠近同步介绍。
  * 点选只改 data-scheme 做预览；确认才写入偏好，「稍后再说」把画面拨回打开前。
- * 预览延后一帧写入（见 schedulePreviewThemeScheme），点击帧只画卡片的选中态。
+ *
+ * 打开期间 App 把 <main>（今日列表）搁起，遮罩用不透明的 bg-ink：预览时整屏只有
+ * 这层底色、弹层和文字要重画，切换即时；关闭后列表原样回来（content-visibility 保留状态）。
  */
 interface Props {
   open: boolean
@@ -72,7 +69,6 @@ export function SchemeOnboardingPrompt({
   }
 
   const restoreBaseline = useCallback(() => {
-    cancelScheduledPreview()
     previewThemeScheme(baselineRef.current, customScheme)
   }, [customScheme])
 
@@ -82,15 +78,12 @@ export function SchemeOnboardingPrompt({
   }, [onDismiss, restoreBaseline])
 
   const confirm = useCallback(() => {
-    // 确认后由偏好落盘统一套用方案；来不及落地的预览直接作废，免得两边抢写 data-scheme
-    cancelScheduledPreview()
     onConfirm(selected)
   }, [onConfirm, selected])
 
   useEffect(() => {
     if (!open) return
     setSelected(initialScheme)
-    return () => cancelScheduledPreview()
   }, [open, initialScheme])
 
   useEffect(() => {
@@ -127,7 +120,7 @@ export function SchemeOnboardingPrompt({
 
   return (
     <div
-      className="fixed inset-0 z-[65] flex items-end justify-center bg-black/50 px-4 md:items-center"
+      className="fixed inset-0 z-[65] flex items-end justify-center bg-ink px-4 md:items-center"
       style={{ paddingBottom: 'calc(var(--sab) + 84px)' }}
       role="presentation"
       onClick={dismiss}
@@ -171,7 +164,7 @@ export function SchemeOnboardingPrompt({
                   aria-pressed={checked}
                   onClick={() => {
                     setSelected(item.id)
-                    schedulePreviewThemeScheme(item.id)
+                    previewThemeScheme(item.id)
                   }}
                   className={`flex w-full flex-col gap-1.5 rounded-xl border p-2 text-left ${
                     checked ? 'border-cinnabar/60 bg-ink' : 'border-haze bg-ink/40'

--- a/src/index.css
+++ b/src/index.css
@@ -584,6 +584,15 @@ html[data-eink='1'] .preset-switcher-sheet {
     contain: layout style;
   }
 
+  /*
+   * 整块内容区搁起：模态引导（风格选择）盖住 <main> 时挂上，
+   * 下层长列表不再参与样式重算与绘制，切换 data-scheme 只剩弹层和壳要重画。
+   * 与 display:none 不同，DOM、布局与滚动位置都保留，摘掉后原样回来。
+   */
+  .content-parked {
+    content-visibility: hidden;
+  }
+
   /* 加载占位：一层缓慢扫过的微光，走 GPU 合成层 */
   .ink-shimmer {
     position: relative;

--- a/src/lib/schemeOnboarding.ts
+++ b/src/lib/schemeOnboarding.ts
@@ -10,41 +10,15 @@ export function schemeOnboardingOptions(): ThemeSchemeMeta[] {
 }
 
 /**
- * 引导里点选预览：只改 html[data-scheme]，不写偏好、不加全站 transition。
+ * 引导里点选预览：同步改 html[data-scheme]，不写偏好、不加全站 transition。
  * 点选若走 React update，会重绘整页列表并落盘，INP 会到数秒。
+ *
+ * 能同步写的前提是引导期间 App 已把 <main> 搁起（.content-parked → content-visibility: hidden）：
+ * 下层数千条列表不参与样式重算与绘制，一次切换只剩弹层和壳要重画，和「我的 → 外观」一样轻。
+ * 曾试过把整页改写推到下一帧（嵌套 rAF），但整页重排本身没变少，预览照样要等，已撤掉。
  */
 export function previewThemeScheme(scheme: ThemeScheme, custom?: CustomSchemePrefs): void {
   applyThemeScheme(scheme, { animate: false, custom })
-}
-
-let cancelPendingPreview: (() => void) | undefined
-
-/**
- * 点选后的预览分两拍：点击这一帧只让卡片的选中态上屏，整页 data-scheme 改写留到下一帧。
- *
- * 根上的 --tone-* 一变，全文档都要重算样式、重排、整屏重绘（数千节点的列表在慢机上是几百毫秒
- * 到数秒）。若和点击落在同一帧，用户要等整页重排完才看到勾选，INP 被整段拖长。
- * 事件里注册的 rAF 仍在本帧绘制前触发，因此要再嵌一层才真正落到本帧提交之后。
- * 连点多张卡只保留最后一张；关闭或确认前调 cancelScheduledPreview，避免迟到的预览盖掉恢复/落盘结果。
- */
-export function schedulePreviewThemeScheme(scheme: ThemeScheme, custom?: CustomSchemePrefs): void {
-  cancelScheduledPreview()
-  if (typeof requestAnimationFrame !== 'function') {
-    previewThemeScheme(scheme, custom)
-    return
-  }
-  let frame = requestAnimationFrame(() => {
-    frame = requestAnimationFrame(() => {
-      cancelPendingPreview = undefined
-      previewThemeScheme(scheme, custom)
-    })
-  })
-  cancelPendingPreview = () => cancelAnimationFrame(frame)
-}
-
-export function cancelScheduledPreview(): void {
-  cancelPendingPreview?.()
-  cancelPendingPreview = undefined
 }
 
 export function shouldShowSchemeOnboarding(input: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

#38 的嵌套 rAF 未能解决引导里换主题的卡顿：预览仍要等整页 Feed 重算。用户对比发现「我的 → 外观」切换实时流畅。

## 根因

- 外观页：不透明 `SettingsShell` 盖在轻量 `MeScreen` 上，可绘节点很少。
- 引导弹窗：半透明遮罩叠在数千条 `ArticleItem` 上；改 `html[data-scheme]` 必须重算并重绘整页列表。

## 改动

- 引导打开时给 `<main>` 加 `content-parked`（`content-visibility: hidden`），保留 DOM/滚动，关闭后恢复。
- 遮罩改为不透明 `bg-ink`，跟随主题预览变色。
- 点选恢复同步 `previewThemeScheme`，撤掉无效的双 rAF。

## 验证

- `test:scheme-onboarding` / `test:theme` / tsc / oxlint 通过
- CDP：点选 style ~1 ms；4× CPU 下 style 约 5–7 ms（修前同规模 DOM 百毫秒级）
- 契约：稍后再说恢复 baseline；就用这个写偏好；关闭后列表可见与 scrollTop 保持

视觉变化：引导期间不再透过半透明看到背后列表，而是干净主题底色。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-280748c8-aca4-4c8f-82b1-a678cec6ee11?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-280748c8-aca4-4c8f-82b1-a678cec6ee11&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

