### PR TITLE
fix(account): 修复 AI 迁移后同步投影与 Secret 落盘 CI

### DIFF
--- a/scripts/sync-projection.test.ts
+++ b/scripts/sync-projection.test.ts
@@ -138,10 +138,24 @@ function recordsFromProjection(state: LocalRuntimeState): SyncRecord[] {
 
 {
   const state = baseState()
-  state.prefs.translation.cloud.openai = {
-    ...state.prefs.translation.cloud.openai,
-    apiKey: 'sk-openai-secret',
-    model: 'gpt-4o-mini',
+  // AI 迁移后：模型真相在 ai.translation；cloud.openai.model 由镜像回填。
+  // 密钥仍可从旧 cloud.openai.apiKey 迁入 Provider / secret。
+  state.prefs.translation = {
+    ...state.prefs.translation,
+    cloud: {
+      ...state.prefs.translation.cloud,
+      openai: {
+        ...state.prefs.translation.cloud.openai,
+        apiKey: 'sk-openai-secret',
+      },
+    },
+    ai: {
+      ...state.prefs.translation.ai,
+      translation: {
+        ...state.prefs.translation.ai.translation,
+        model: 'gpt-4o-mini',
+      },
+    },
   }
   state.prefs.proxy = { ...state.prefs.proxy, proxyUrl: 'socks5://127.0.0.1:1080' }
 

--- a/src/features/account/secretStore.ts
+++ b/src/features/account/secretStore.ts
@@ -62,8 +62,11 @@ function legacyOpenAiMirrorValue(prefs: Preferences): string {
 function collectSecretsWithLegacyMirror(prefs: Preferences): Record<string, string> {
   const values = collectSecrets(prefs)
   const legacyValue = legacyOpenAiMirrorValue(prefs)
+  // AI 翻译 Key 是旧 OpenAI secret 的镜像源；有值时覆盖写入，便于降级旧客户端。
+  // AI 为空时不要删掉 collectSecrets 已读到的 cloud.openai.apiKey——历史明文迁移与
+  // 尚未 normalize 的瞬时态仍靠旧字段进 Keystore。两边都空时该键本就不在 values 里，
+  // persistRuntimeSecrets 仍会清掉对应 SecureStore 条目。
   if (legacyValue) values[LEGACY_OPENAI_SECRET_KEY] = legacyValue
-  else delete values[LEGACY_OPENAI_SECRET_KEY]
   return values
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

Cloud Sync CI 在 AI 翻译迁移后连续失败：
1. `test:sync-projection`：`非密钥字段照常同步`
2. `test:secure-secret-hydration`：`persistRuntimeSecrets` 写不出 OpenAI Key

与主题引导 #39 无关，但会挡住后续合并。

## 改动

1. **测试**：Secret 分离用例改为在权威路径 `ai.translation.model` 写入模型。
2. **产品**：`collectSecretsWithLegacyMirror` 不再在 AI Key 为空时 `delete` 已从 `cloud.openai.apiKey` 收集到的旧密钥，避免历史明文 / 瞬时态在落 Keystore 前被抹掉。

## 验证

本地已过：`test:sync-projection`、`test:secure-secret-hydration`、`test:sync-engine`、`test:account-auth`、`test:cloud-sync-runtime`、`test:account-sync-ui`、`test:sync-notifier`、`scripts/ai-provider-sync.test.ts`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-280748c8-aca4-4c8f-82b1-a678cec6ee11?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-280748c8-aca4-4c8f-82b1-a678cec6ee11&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

