### PR TITLE
fix(translation): 长文 AI 翻译重试只补失败段，并修正「显示原文」状态缺口

### DIFF
--- a/scripts/openai-provider.test.ts
+++ b/scripts/openai-provider.test.ts
@@ -387,6 +387,49 @@ assert.equal(bestEffortCalls.get('Fail'), 1)
 assert.equal(bestEffortCalls.get('One'), 1)
 assert.equal(bestEffortCalls.get('Three'), 1)
 
+// 同一 Provider 实例重试时只补失败段：已成功段直接复用，不再重发整篇。
+globalThis.fetch = async (_input, init) => {
+  const body = JSON.parse(String(init?.body)) as {
+    messages: { role: string; content: string }[]
+  }
+  const user = body.messages.find((message) => message.role === 'user')?.content ?? ''
+  const plain = user.match(/^原文：\n([\s\S]+)$/)
+  const text = plain?.[1] ?? user
+  bestEffortCalls.set(text, (bestEffortCalls.get(text) ?? 0) + 1)
+  await new Promise((resolve) => setTimeout(resolve, 5))
+  return Response.json({ choices: [{ message: { content: `AI:${text}` } }] })
+}
+const resumedIndexes: number[] = []
+const resumed = await providerFive.translate({
+  texts: ['One', 'Fail', 'Three'],
+  sourceLanguage: 'en',
+  targetLanguage: 'zh-Hans',
+  onBatch: (_batch, startIndex) => resumedIndexes.push(startIndex),
+})
+assert.deepEqual(resumed, ['AI:One', 'AI:Fail', 'AI:Three'])
+assert.deepEqual(
+  resumedIndexes.sort((a, b) => a - b),
+  [0, 1, 2],
+  'resumed run must still report every segment through onBatch',
+)
+assert.equal(bestEffortCalls.get('Fail'), 2, 'only the failed segment is re-requested')
+assert.equal(bestEffortCalls.get('One'), 1, 'completed segments are reused on retry')
+assert.equal(bestEffortCalls.get('Three'), 1, 'completed segments are reused on retry')
+
+// 语向不同不能复用：同一文本换目标语言必须重新请求
+await providerFive.translate({ texts: ['One'], sourceLanguage: 'en', targetLanguage: 'ja' })
+assert.equal(bestEffortCalls.get('One'), 2, 'different target language must not hit the cache')
+
+// 新实例不共享缓存：设置页「测试 AI 翻译」每次都真实发请求
+const freshProvider = new OpenAiProvider({
+  apiKey: 'sk-test',
+  endpoint: 'https://api.openai.com/v1',
+  model: 'gpt-4o-mini',
+  concurrency: 5,
+})
+await freshProvider.translate({ texts: ['Three'], sourceLanguage: 'en', targetLanguage: 'zh-Hans' })
+assert.equal(bestEffortCalls.get('Three'), 2, 'a new provider instance starts with an empty cache')
+
 // 同一次调用内重复文本只请求一次，结果按原顺序展开，onBatch 仍逐条回调
 let dedupCalls = 0
 globalThis.fetch = async (_input, init) => {

--- a/src/features/translation/providers.ts
+++ b/src/features/translation/providers.ts
@@ -738,8 +738,26 @@ export class DeepLXProvider extends CloudProvider {
   }
 }
 
+/** 单个 OpenAiProvider 实例最多记住多少段成功译文（约两篇长文） */
+const OPENAI_COMPLETED_CACHE_LIMIT = 256
+
 export class OpenAiProvider extends CloudProvider {
   readonly id = 'openai' as const
+  /**
+   * 本实例已成功的段落译文。长文里个别段落失败后用户点「重试」，
+   * 只需补失败段，不必把整篇再发一遍。Reader 复用同一实例；
+   * 设置页「测试 AI 翻译」每次新建实例，不受影响。
+   */
+  private readonly completed = new Map<string, string>()
+
+  private remember(key: string, value: string): void {
+    this.completed.delete(key)
+    this.completed.set(key, value)
+    if (this.completed.size > OPENAI_COMPLETED_CACHE_LIMIT) {
+      const oldest = this.completed.keys().next().value
+      if (oldest !== undefined) this.completed.delete(oldest)
+    }
+  }
 
   async translate(request: TranslationRequest): Promise<string[]> {
     const base = assertOpenAiConfig(this.config)
@@ -751,8 +769,10 @@ export class OpenAiProvider extends CloudProvider {
       throw new Error('AI 翻译：textKinds 与 texts 长度不一致')
     }
 
-    // 同一次调用内「文本 + 场景」相同的段落只发一次请求，重复段共享在途结果
+    // 同一次调用内「语向 + 场景 + 文本」相同的段落只发一次请求，重复段共享在途结果
     const inflightByKey = new Map<string, Promise<string>>()
+    const cacheKey = (text: string, kind: TranslationTextKind) =>
+      `${request.sourceLanguage}\u0000${request.targetLanguage}\u0000${kind}\u0000${text}`
     const translateSingle = async (text: string, kind: TranslationTextKind): Promise<string> => {
       const system = openAiTranslationSystemPrompt(
         request.sourceLanguage,
@@ -824,10 +844,15 @@ export class OpenAiProvider extends CloudProvider {
       concurrency,
       (text, index) => {
         const kind = request.textKinds?.[index] ?? 'paragraph'
-        const key = `${kind}\u0000${text}`
+        const key = cacheKey(text, kind)
+        const done = this.completed.get(key)
+        if (done !== undefined) return Promise.resolve(done)
         let pending = inflightByKey.get(key)
         if (!pending) {
-          pending = translateSingle(text, kind)
+          pending = translateSingle(text, kind).then((translated) => {
+            this.remember(key, translated)
+            return translated
+          })
           inflightByKey.set(key, pending)
         }
         return pending

--- a/src/screens/ReaderScreen.tsx
+++ b/src/screens/ReaderScreen.tsx
@@ -731,6 +731,12 @@ export function ReaderScreen({
     [article, resolvedTitle],
   )
 
+  // 同一份偏好复用一个实例：AI 翻译部分失败后「重试」只补失败段，不重发已成功段
+  const translationService = useMemo(
+    () => createTranslationService(translationPrefs),
+    [translationPrefs],
+  )
+
   const speedReadConfig = useMemo(
     () => resolveAiFeatureConfig({ ai: translationPrefs.ai }, 'speedRead'),
     [translationPrefs.ai],
@@ -1221,7 +1227,7 @@ export function ReaderScreen({
         if (!pending || controller.signal.aborted) return
         setTranslated(pending)
       }
-      const result = await createTranslationService(translationPrefs).translateArticle(
+      const result = await translationService.translateArticle(
         article.title,
         html,
         translationPrefs,
@@ -1516,6 +1522,9 @@ export function ReaderScreen({
                       <button
                         type="button"
                         onClick={() => {
+                          // 保留的只是半篇译文：回原文后清掉，下次点「翻译」重新走一遍
+                          //（已成功段由 Provider 缓存秒回），不能被当成完整译文直接展示。
+                          setTranslated(null)
                           setShowTranslation(false)
                           setTranslationError('')
                           setTranslationState('idle')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

用户反馈：长文 AI 翻译并发像卡在 2、翻译很久后模型已返回但 App 报超时/失败，且已成功句子也会「崩溃」。

审查结论：**这是 App 侧问题，不是用户 API 问题。** 你在 main（1.7.3，commit `cd78d48`）上的一轮修复已命中根因（删整篇 60s 超时、best-effort 分片、并发输入草稿态），但尚未发版到用户手中的 v1.7.2。

## 本 PR 补齐遗留缺口

在已有 partial-retention 基础上：

1. **重试只补失败段**：`OpenAiProvider` 实例内记住成功段（有界 LRU），`ReaderScreen` 复用同一 `TranslationService`，「重试翻译」不再把整篇再发一遍。
2. **「显示原文」状态缺口**：错误横幅点「显示原文」不再保留半篇 `translated` 却回到 idle，避免下次点「翻译」把半篇当完整译文展示。

## 验证

- `npm run test:openai`
- `npm run test:translation`
- `npm run test:openai-news-body`
- `tsc -b`（需先 `build:contracts`）
- oxlint 对改动文件无警告

## 说明

- 未改 `types.ts` 边界，未引入新依赖，未动 cloud/local 变体。
- 云端子代理审查模型：`claude-fable-5-1-thinking-xhigh`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e04bf764-a35a-4fde-ae72-299f74ed6857?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e04bf764-a35a-4fde-ae72-299f74ed6857&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

